### PR TITLE
Eliminating Swift 1.2 warnings

### DIFF
--- a/CryptoSwift/AES.swift
+++ b/CryptoSwift/AES.swift
@@ -115,7 +115,6 @@ public class AES {
         
         if (blockMode.requireIV() && iv.length != key.length) {
             assertionFailure("Key and Initialization Vector must be the same length!")
-            return nil
         }
     }
     
@@ -148,7 +147,6 @@ public class AES {
         } else if (message.length % AES.blockSizeBytes() != 0) {
             // 128 bit block exceeded, need padding
             assertionFailure("AES 128-bit block exceeded!")
-            return nil
         }
         
         let blocks = finalMessage.bytes().chunks(AES.blockSizeBytes())
@@ -193,7 +191,6 @@ public class AES {
         if (message.length % AES.blockSizeBytes() != 0) {
             // 128 bit block exceeded
             assertionFailure("AES 128-bit block exceeded!")
-            return nil
         }
         
         let blocks = message.bytes().chunks(AES.blockSizeBytes())

--- a/CryptoSwift/CipherBlockMode.swift
+++ b/CryptoSwift/CipherBlockMode.swift
@@ -76,7 +76,6 @@ private struct CBCMode {
         
         if (iv == nil) {
             assertionFailure("CBC require IV")
-            return nil
         }
         
         var out:[UInt8]?
@@ -106,7 +105,6 @@ private struct CBCMode {
     static func decryptBlocks(blocks:[[UInt8]], iv:[UInt8]?, cipher:CipherWorker) -> [UInt8]? {
         if (iv == nil) {
             assertionFailure("CBC require IV")
-            return nil
         }
 
         var out:[UInt8]?
@@ -139,7 +137,6 @@ private struct CFBMode {
         
         if (iv == nil) {
             assertionFailure("CFB require IV")
-            return nil
         }
         
         var out:[UInt8]?
@@ -166,7 +163,6 @@ private struct CFBMode {
     static func decryptBlocks(blocks:[[UInt8]], iv:[UInt8]?, cipher:CipherWorker) -> [UInt8]? {
         if (iv == nil) {
             assertionFailure("CFB require IV")
-            return nil
         }
         
         var out:[UInt8]?


### PR DESCRIPTION
Apparently no “return nil” is needed after an assertionFailure.