### PR TITLE
[FIX] Memory leak with unsafe calloc

### DIFF
--- a/CryptoSwift/HashBase.swift
+++ b/CryptoSwift/HashBase.swift
@@ -29,15 +29,21 @@ internal class HashBase {
         tmpMessage.appendBytes([0x80]) // append one bit (UInt8 with one bit) to message
         
         // append "0" bit until message length in bits ≡ 448 (mod 512)
-        var msgLength = tmpMessage.length;
-        var counter = 0;
+        var msgLength = tmpMessage.length
+        var counter = 0
+      
         while msgLength % len != (len - 8) {
             counter++
             msgLength++
         }
+      
         var bufZeros = UnsafeMutablePointer<UInt8>(calloc(counter, sizeof(UInt8)))
+      
         tmpMessage.appendBytes(bufZeros, length: counter)
-        
+      
+        bufZeros.destroy()
+        bufZeros.dealloc(1)
+      
         return tmpMessage
     }
 }


### PR DESCRIPTION
Hi,

I found a memory leak on your library while debugging my app. If I targeted the issue correctly (and well understood your lib), the leak concerns an unsafe pointer over a `calloc` which is not deallocated in the `prepare` method of the `HashBase` class.

Thank you for your great lib. ;)

Best,

Yannick