### PR TITLE
Add a message to @deprecated attribute to make it less confusing. Fixes #50

### DIFF
--- a/CryptoSwift/Generics.swift
+++ b/CryptoSwift/Generics.swift
@@ -36,7 +36,7 @@ func integerFromBitsArray<T: UnsignedIntegerType>(bits: [Bit]) -> T
 
 /// Initialize integer from array of bytes.
 /// I found this method slow
-@availability(*, deprecated=0.8)
+@availability(*, deprecated=0.8, message="Deprecated but replacement is not yet available.")
 func integerWithBytes<T: IntegerType>(bytes: [UInt8]) -> T {
     var totalBytes = Swift.min(bytes.count, sizeof(T))
     // get slice of Int


### PR DESCRIPTION
Add a message to @deprecated attribute to make it less confusing. Fixes #50