### PR TITLE
Test Classes changes

### DIFF
--- a/CryptoSwiftTests/AESTests.swift
+++ b/CryptoSwiftTests/AESTests.swift
@@ -179,10 +179,8 @@ class AESTests: XCTestCase {
         let key:[UInt8] = [0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c];
         let iv:[UInt8] = [0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F]
         let message = [UInt8](count: 1024 * 1024, repeatedValue: 7)
-        self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
-            self.startMeasuring()
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true, forBlock: { () -> Void in
             let encrypted = AES(key: key, iv: iv, blockMode: .CBC)?.encrypt(message, padding: PKCS7())
-            self.stopMeasuring()
         })
     }
     
@@ -191,9 +189,7 @@ class AESTests: XCTestCase {
         let iv:[UInt8] = [0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F]
         let message = [UInt8](count: 1024 * 1024, repeatedValue: 7)
         
-        self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
-            self.startMeasuring()
-            
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
             let keyData     = NSData.withBytes(key)
             let keyBytes    = UnsafePointer<Void>(keyData.bytes)
             let ivData      = NSData.withBytes(iv)
@@ -208,6 +204,8 @@ class AESTests: XCTestCase {
             let cryptLength  = cryptData!.length
             
             var numBytesEncrypted:Int = 0
+            
+            self.startMeasuring()
             
             var cryptStatus = CCCrypt(
                 UInt32(kCCEncrypt),

--- a/CryptoSwiftTests/ChaCha20Tests.swift
+++ b/CryptoSwiftTests/ChaCha20Tests.swift
@@ -75,8 +75,7 @@ class ChaCha20Tests: XCTestCase {
         let key:[UInt8] = [0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c];
         let iv:[UInt8] = [0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F]
         let message = [UInt8](count: (1024 * 1024) * 1, repeatedValue: 7)
-        self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
-            self.startMeasuring()
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: true, forBlock: { () -> Void in
             let encrypted = ChaCha20(key: key, iv: iv)?.encrypt(message)
             self.stopMeasuring()
             XCTAssert(encrypted != nil, "not encrypted")

--- a/CryptoSwiftTests/ExtensionsTest.swift
+++ b/CryptoSwiftTests/ExtensionsTest.swift
@@ -21,7 +21,7 @@ class ExtensionsTest: XCTestCase {
     }
 
     func testArrayChunksPerformance() {
-        self.measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
+        measureMetrics([XCTPerformanceMetric_WallClockTime], automaticallyStartMeasuring: false, forBlock: { () -> Void in
             let message = [UInt8](count: 1024 * 1024, repeatedValue: 7)
             self.startMeasuring()
             let blocks = message.chunks(AES.blockSize)

--- a/CryptoSwiftTests/HashTests.swift
+++ b/CryptoSwiftTests/HashTests.swift
@@ -203,7 +203,7 @@ class CryptoSwiftTests: XCTestCase {
             expect.fulfill()
         })
 
-        self.waitForExpectationsWithTimeout(10, handler: { (error) -> Void in
+        waitForExpectationsWithTimeout(10, handler: { (error) -> Void in
             XCTAssertNil(error, "CRC32 async failed")
         })
     }


### PR DESCRIPTION
Test Classes changes:
Don't measure the boilerplate code needed to get the data ready for CommonCrypto.
We rarely need to explicitly use self notation, unless we're in a block.
Have some metric measurement start measuring.