### PR TITLE
Remove CryptoSwift namepsace for iOS7

### DIFF
--- a/CryptoSwift/Authenticator.swift
+++ b/CryptoSwift/Authenticator.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+private typealias CryptoSwift_HMAC      = HMAC
+private typealias CryptoSwift_Poly1305  = Poly1305
+
 /**
 *  Message Authentication
 */
@@ -18,7 +21,7 @@ public enum Authenticator {
     :param: key 256-bit key
     */
     case Poly1305(key: [UInt8])
-    case HMAC(key: [UInt8], variant:CryptoSwift.HMAC.Variant)
+    case HMAC(key: [UInt8], variant:CryptoSwift_HMAC.Variant)
     
     /**
     Generates an authenticator for message using a one-time key and returns the 16-byte result
@@ -28,9 +31,9 @@ public enum Authenticator {
     public func authenticate(message: [UInt8]) -> [UInt8]? {
         switch (self) {
         case .Poly1305(let key):
-            return CryptoSwift.Poly1305.authenticate(key: key, message: message)
+            return CryptoSwift_Poly1305.authenticate(key: key, message: message)
         case .HMAC(let key, let variant):
-            return CryptoSwift.HMAC.authenticate(key: key, message: message, variant: variant)
+            return CryptoSwift_HMAC.authenticate(key: key, message: message, variant: variant)
         }
     }
 }

--- a/CryptoSwift/Cipher.swift
+++ b/CryptoSwift/Cipher.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+private typealias CryptoSwift_ChaCha20  = ChaCha20
+private typealias CryptoSwift_AES       = AES
+
 public enum Cipher {
     /**
     ChaCha20
@@ -39,10 +42,10 @@ public enum Cipher {
     public func encrypt(bytes: [UInt8]) -> [UInt8]? {
         switch (self) {
             case .ChaCha20(let key, let iv):
-                var chacha = CryptoSwift.ChaCha20(key: key, iv: iv)
+                var chacha = CryptoSwift_ChaCha20(key: key, iv: iv)
                 return chacha?.encrypt(bytes)
             case .AES(let key, let iv, let blockMode):
-                var aes = CryptoSwift.AES(key: key, iv: iv, blockMode: blockMode)
+                var aes = CryptoSwift_AES(key: key, iv: iv, blockMode: blockMode)
                 return aes?.encrypt(bytes)
         }
     }
@@ -57,10 +60,10 @@ public enum Cipher {
     public func decrypt(bytes: [UInt8]) -> [UInt8]? {
         switch (self) {
             case .ChaCha20(let key, let iv):
-                var chacha = CryptoSwift.ChaCha20(key: key, iv: iv);
+                var chacha = CryptoSwift_ChaCha20(key: key, iv: iv);
                 return chacha?.decrypt(bytes)
             case .AES(let key, let iv, let blockMode):
-                var aes = CryptoSwift.AES(key: key, iv: iv, blockMode: blockMode);
+                var aes = CryptoSwift_AES(key: key, iv: iv, blockMode: blockMode);
                 return aes?.decrypt(bytes)
         }
     }

--- a/CryptoSwift/IntExtension.swift
+++ b/CryptoSwift/IntExtension.swift
@@ -40,14 +40,12 @@ extension Int {
     }
 }
 
-
-
 /** Shift bits */
 extension Int {
     
     /** Shift bits to the left. All bits are shifted (including sign bit) */
     private mutating func shiftLeft(count: Int) -> Int {
-        self = CryptoSwift.shiftLeft(self, count)
+        self = CryptoSwift_shiftLeft(self, count)
         return self
     }
     
@@ -105,4 +103,8 @@ func &>> (lhs: Int, rhs: Int) -> Int {
     var l = lhs;
     l.shiftRight(rhs)
     return l
+}
+
+func CryptoSwift_shiftLeft(value: Int, count: Int) -> Int {
+    return shiftLeft(value, count)
 }

--- a/CryptoSwift/MD5.swift
+++ b/CryptoSwift/MD5.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class MD5 : CryptoSwift.HashBase, _Hash {
+final class MD5 : HashBase, _Hash {
     var size:Int = 16 // 128 / 8
     
     /** specifies the per-round shift amounts */

--- a/CryptoSwift/SHA1.swift
+++ b/CryptoSwift/SHA1.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class SHA1 : CryptoSwift.HashBase, _Hash {
+final class SHA1 : HashBase, _Hash {
     var size:Int = 20 // 160 / 8
     
     override init(_ message: NSData) {


### PR DESCRIPTION
This will remove CryptoSwift namepsace and can be imported to iOS7 project.

1. Use type alias to different the enum function and class function.
2. User third function to different Int shiftLeft and Generic shiftLeft.
3. Remove HashBases namespace.