### PR TITLE
Xcode automatic changes to the watchOS scheme

### DIFF
--- a/CryptoSwift.xcodeproj/xcshareddata/xcschemes/CryptoSwift watchOS.xcscheme
+++ b/CryptoSwift.xcodeproj/xcshareddata/xcschemes/CryptoSwift watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5596BDBA1BC8F220007E38D5"
-               BuildableName = "CryptoSwift watchOS.framework"
+               BuildableName = "CryptoSwift.framework"
                BlueprintName = "CryptoSwift watchOS"
                ReferencedContainer = "container:CryptoSwift.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5596BDBA1BC8F220007E38D5"
-            BuildableName = "CryptoSwift watchOS.framework"
+            BuildableName = "CryptoSwift.framework"
             BlueprintName = "CryptoSwift watchOS"
             ReferencedContainer = "container:CryptoSwift.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5596BDBA1BC8F220007E38D5"
-            BuildableName = "CryptoSwift watchOS.framework"
+            BuildableName = "CryptoSwift.framework"
             BlueprintName = "CryptoSwift watchOS"
             ReferencedContainer = "container:CryptoSwift.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
Minor change where Xcode automatically updates the scheme. This ends up marking a CryptoSwift submodule as dirty. Committing this change prevents that.