### PR TITLE
Adding link to CHANGELOG file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 ##Changelog
 
-see CHANGELOG file
+See [CHANGELOG](./CHANGELOG) file.


### PR DESCRIPTION
Simple addition to help those who scrolled the README all the way down. 

Also, it would be possible to update the link at the "header" menu, where Changelog links to the anchor at the bottom of the file. I didn't added that change because I was not sure if that would be the best option, it would make no sense to have a Changelog section at the end of the file. 