### PR TITLE
Possibly a bug: Add public access control to AES.Error and ChaCha20.Error

### DIFF
--- a/CryptoSwift/AES.swift
+++ b/CryptoSwift/AES.swift
@@ -8,7 +8,7 @@
 
 final public class AES {
     
-    enum Error: ErrorType {
+    public enum Error: ErrorType {
         case BlockSizeExceeded
         case InvalidKeyOrInitializationVector
         case InvalidInitializationVector

--- a/CryptoSwift/ChaCha20.swift
+++ b/CryptoSwift/ChaCha20.swift
@@ -8,7 +8,7 @@
 
 final public class ChaCha20 {
     
-    enum Error: ErrorType {
+    public enum Error: ErrorType {
         case MissingContext
     }
     


### PR DESCRIPTION
Fixing the below errors which occurs when try to catch error
out side of CryptoSwift module:
Type 'AES' has no member 'Error'
Type 'ChaCha20' has no member 'Error'