### PR TITLE
updated podspec version for a new release to include tvOS in cocoa pods

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "CryptoSwift"
-  s.version      = "0.1.1"
+  s.version      = "0.1.2"
   s.summary      = "Cryptography in Swift. SHA, MD5, CRC, Poly1305, HMAC, ChaCha20, AES."
   s.description  = "Cryptography functions and helpers for Swift implemented in Swift. SHA, MD5, CRC, Poly1305, HMAC, ChaCha20, AES."
   s.homepage     = "https://github.com/krzyzanowskim/CryptoSwift"


### PR DESCRIPTION
The issue was that cocoa pods is pointing by definition to the version of the podspec (0.1.1).
The podspec update including tvOS was added later on following commits on the master branch without making a tag / release. This leads issues in cocoapods if you don't want to specify a specific branch in your podfile.

`The platform of the target 'Pods' (tvOS 9.0) is not compatible with 'CryptoSwift (0.1.1)', which does not support 'twos'`

I increased the version number to 0.1.2 in podspec. If you create a new tag "0.1.2" after merging my changes the cocoapods should be able to find tvOS support, without the need to specify master branch.