### PR TITLE
Refactored SHA2 final hash generation to solve "Expression was too complex" error.

### DIFF
--- a/Sources/CryptoSwift/SHA2.swift
+++ b/Sources/CryptoSwift/SHA2.swift
@@ -273,8 +273,12 @@ final class SHA2 : HashProtocol {
         result.reserveCapacity(hh.count / 4)
         variant.resultingArray(hh).forEach {
             let item = $0.bigEndian
-            result += [UInt8(item & 0xff), UInt8((item >> 8) & 0xff), UInt8((item >> 16) & 0xff), UInt8((item >> 24) & 0xff),
-                       UInt8((item >> 32) & 0xff),UInt8((item >> 40) & 0xff), UInt8((item >> 48) & 0xff), UInt8((item >> 56) & 0xff)]
+            var chunk = [UInt8]()
+            for i in 0..<8 {
+                let shift = UInt64(8 * i)
+                chunk.append(UInt8((item >> shift) & 0xff))
+            }
+            result += chunk
         }
         return result
     }


### PR DESCRIPTION
- [FIXED] Error: "Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions"