### PR TITLE
avoid swift 3.0 compile error about type inference

### DIFF
--- a/Sources/CryptoSwift/SHA2.swift
+++ b/Sources/CryptoSwift/SHA2.swift
@@ -273,8 +273,9 @@ final class SHA2 : HashProtocol {
         result.reserveCapacity(hh.count / 4)
         variant.resultingArray(hh).forEach {
             let item = $0.bigEndian
-            result += [UInt8(item & 0xff), UInt8((item >> 8) & 0xff), UInt8((item >> 16) & 0xff), UInt8((item >> 24) & 0xff),
-                       UInt8((item >> 32) & 0xff),UInt8((item >> 40) & 0xff), UInt8((item >> 48) & 0xff), UInt8((item >> 56) & 0xff)]
+            let itemArray: [UInt8] = [UInt8(item & 0xff), UInt8((item >> 8) & 0xff), UInt8((item >> 16) & 0xff), UInt8((item >> 24) & 0xff),
+                                      UInt8((item >> 32) & 0xff),UInt8((item >> 40) & 0xff), UInt8((item >> 48) & 0xff), UInt8((item >> 56) & 0xff)]
+            result += itemArray
         }
         return result
     }


### PR DESCRIPTION
Apple Swift version 3.0-dev (LLVM a7663bb722, Clang 4ca3c7fa28, Swift 1c2f40e246) Target: x86_64-apple-macosx10.9 makes
error: expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions
for the array literal addition.