### PR TITLE
Add a constructor to `NoPadding`

### DIFF
--- a/Sources/CryptoSwift/NoPadding.swift
+++ b/Sources/CryptoSwift/NoPadding.swift
@@ -7,6 +7,10 @@
 //
 
 public struct NoPadding: Padding {
+    public init() {
+    
+    }
+    
     public func add(data: [UInt8], blockSize:Int) -> [UInt8] {
         return data;
     }


### PR DESCRIPTION
**What's this PR for?**

Add a constructor to struct `NoPadding` to fix compilation error when using `NoPadding()`.

**What's going on?**

While using the example code in `README`:

> [AES without data padding](https://github.com/krzyzanowskim/CryptoSwift#aes)

```swift
let encrypted: [UInt8] = try! AES(key: "secret0key000000", iv:"0123456789012345", blockMode: .CBC, padding: NoPadding()).encrypt(input)
```

The code won't compile and the complier is emitting this error:

```
'NoPadding' cannot be constructed because it has no accessible initializers
```