### PR TITLE
Check against instance-level `iv` in AES.init()

### DIFF
--- a/Sources/CryptoSwift/AES.swift
+++ b/Sources/CryptoSwift/AES.swift
@@ -102,7 +102,7 @@ final public class AES: BlockCipher {
             self.iv = defaultIV
         }
 
-        if (blockMode.options.contains(.InitializationVectorRequired) && iv?.count != AES.blockSize) {
+        if (blockMode.options.contains(.InitializationVectorRequired) && self.iv.count != AES.blockSize) {
             assert(false, "Block size and Initialization Vector must be the same length!")
             throw Error.InvalidInitializationVector
         }


### PR DESCRIPTION
Check against `self.iv` instead of the optional init argument `iv`. This should fix #261