### PR TITLE
Remove hasPrefix from String extensions

### DIFF
--- a/Sources/CryptoSwift/String+Extension.swift
+++ b/Sources/CryptoSwift/String+Extension.swift
@@ -55,10 +55,4 @@ extension String {
     public func authenticate<A: Authenticator>(with authenticator: A) throws -> String {
         return try self.utf8.lazy.map({ $0 as UInt8 }).authenticate(with: authenticator).toHexString()
     }
-    
-    #if !_runtime(_ObjC)
-    public func hasPrefix(_ prefix: String) -> Bool {
-        return prefix == String(self.characters.prefix(prefix.characters.count))
-    }
-    #endif
 }


### PR DESCRIPTION
Swift 3.0 release has this method implemented