### PR TITLE
Added Crossplatform Randomizer

### DIFF
--- a/Sources/CryptoSwift/Cryptors.swift
+++ b/Sources/CryptoSwift/Cryptors.swift
@@ -30,10 +30,6 @@ public protocol Cryptors: class {
 
 extension Cryptors {
     static public func randomIV(_ blockSize:Int) -> Array<UInt8> {
-        var randomIV:Array<UInt8> = Array<UInt8>();
-        for _ in 0..<blockSize {
-            randomIV.append(UInt8(truncatingBitPattern: cs_arc4random_uniform(256)));
-        }
-        return randomIV
+        return URandom.shared.random(numBytes: blockSize)
     }
 }

--- a/Sources/CryptoSwift/Multiplatform.swift
+++ b/Sources/CryptoSwift/Multiplatform.swift
@@ -5,18 +5,98 @@
 //  Created by Marcin Krzyzanowski on 03/12/15.
 //  Copyright © 2015 Marcin Krzyzanowski. All rights reserved.
 //
+//  URandom originally from https://github.com/stormpath/Turnstile/blob/master/Sources/TurnstileCrypto/URandom.swift
+//  
 
-#if os(Linux)
+import Foundation
+
+#if os(Linux) || os(FreeBSD)
     import Glibc
-    import SwiftShims
 #else
     import Darwin
 #endif
 
-func cs_arc4random_uniform(_ upperBound: UInt32) -> UInt32 {
-    #if os(Linux)
-        return _swift_stdlib_cxx11_mt19937_uniform(upperBound)
-    #else
-        return arc4random_uniform(upperBound)
-    #endif
+public class URandom {
+    
+    public static var shared = URandom()
+    
+    private let file = fopen("/dev/urandom", "r")
+    
+    /// Initialize URandom
+    public init() {}
+    
+    deinit {
+        fclose(file)
+    }
+    
+    private func read(numBytes: Int) -> [Int8] {
+        // Initialize an empty array with numBytes+1 for null terminated string
+        var bytes = [Int8](repeating: 0, count: numBytes + 1)
+        fgets(&bytes, numBytes + 1, file)
+        
+        bytes.removeLast()
+        
+        return bytes
+    }
+    
+    /// Get a byte array of random UInt8s
+    public func random(numBytes: Int) -> [UInt8] {
+        return unsafeBitCast(read(numBytes: numBytes), to: [UInt8].self)
+    }
+    
+    /// Get a random int8
+    public var int8: Int8 {
+        return Int8(read(numBytes: 1)[0])
+    }
+    
+    /// Get a random uint8
+    public var uint8: UInt8 {
+        return UInt8(bitPattern: int8)
+    }
+    
+    /// Get a random int16
+    public var int16: Int16 {
+        let bytes = read(numBytes: 2)
+        return UnsafeMutableRawPointer(mutating: bytes).assumingMemoryBound(to: Int16.self).pointee
+    }
+    
+    /// Get a random uint16
+    public var uint16: UInt16 {
+        return UInt16(bitPattern: int16)
+    }
+    
+    /// Get a random int32
+    public var int32: Int32 {
+        let bytes = read(numBytes: 4)
+        return UnsafeMutableRawPointer(mutating: bytes).assumingMemoryBound(to: Int32.self).pointee
+    }
+    
+    /// Get a random uint32
+    public var uint32: UInt32 {
+        return UInt32(bitPattern: int32)
+    }
+    
+    /// Get a random int64
+    public var int64: Int64 {
+        let bytes = read(numBytes: 8)
+        return UnsafeMutableRawPointer(mutating: bytes).assumingMemoryBound(to: Int64.self).pointee
+    }
+    
+    /// Get a random uint64
+    public var uint64: UInt64 {
+        return UInt64(bitPattern: int64)
+    }
+    
+    /// Get a random int
+    public var int: Int {
+        let bytes = read(numBytes: MemoryLayout<Int>.size)
+        return UnsafeMutableRawPointer(mutating: bytes).assumingMemoryBound(to: Int.self).pointee
+    }
+    
+    /// Get a random uint
+    public var uint: UInt {
+        return UInt(bitPattern: int)
+    }
 }
+
+


### PR DESCRIPTION
Hi,

I'm trying to write a simple piece of code that AES encrypts a passcode with a key and IV. The key and IV are generated randomly every time. This code works fine on macOS. But on Linux, the random keys are the same every time the program runs. I have had this problem before. The basic random functions on linux are Turnstile in nature. I found a solution with my own code. It was a basic class that opened /dev/random and read bits off of it on demand. I was wondering if you would be interested in a PR for Multiplatform.swift where the linux aspect of randomization was replaced with this randomizer I've been using on linux.

The code is originally from https://github.com/stormpath/Turnstile/blob/master/Sources/TurnstileCrypto/URandom.swift 

After creating this fork and changing out the randomizer I realized that Crypto swift doesn't actually use the randomizer. So let me know if you actually want to go in the direction of removing the randomizer instead of improving it :p. Or if you have anything you want me to change.

Thanks!

-Jeff