### PR TITLE
Compile under Xcode 9 / Swift 3.2

### DIFF
--- a/Sources/CryptoSwift/AES.swift
+++ b/Sources/CryptoSwift/AES.swift
@@ -197,12 +197,27 @@ fileprivate extension AES {
         b2 = F1(t[2], t[3], t[0], t[1]) ^ rk[rounds][2]
         b3 = F1(t[3], t[0], t[1], t[2]) ^ rk[rounds][3]
 
+        let r0 = UInt8(b0 & 0xFF)
+        let r1 = UInt8((b0 >> 8) & 0xFF)
+        let r2 = UInt8((b0 >> 16) & 0xFF)
+        let r3 = UInt8((b0 >> 24) & 0xFF)
+        let r4 = UInt8(b1 & 0xFF)
+        let r5 = UInt8((b1 >> 8) & 0xFF)
+        let r6 = UInt8((b1 >> 16) & 0xFF)
+        let r7 = UInt8((b1 >> 24) & 0xFF)
+        let r8 = UInt8(b2 & 0xFF)
+        let r9 = UInt8((b2 >> 8) & 0xFF)
+        let r10 = UInt8((b2 >> 16) & 0xFF)
+        let r11 = UInt8((b2 >> 24) & 0xFF)
+        let r12 = UInt8(b3 & 0xFF)
+        let r13 = UInt8((b3 >> 8) & 0xFF)
+        let r14 = UInt8((b3 >> 16) & 0xFF)
+        let r15 = UInt8((b3 >> 24) & 0xFF)
         return [
-            UInt8(b0 & 0xFF),UInt8((b0 >> 8) & 0xFF),UInt8((b0 >> 16) & 0xFF),UInt8((b0 >> 24) & 0xFF),
-            UInt8(b1 & 0xFF),UInt8((b1 >> 8) & 0xFF),UInt8((b1 >> 16) & 0xFF),UInt8((b1 >> 24) & 0xFF),
-            UInt8(b2 & 0xFF),UInt8((b2 >> 8) & 0xFF),UInt8((b2 >> 16) & 0xFF),UInt8((b2 >> 24) & 0xFF),
-            UInt8(b3 & 0xFF),UInt8((b3 >> 8) & 0xFF),UInt8((b3 >> 16) & 0xFF),UInt8((b3 >> 24) & 0xFF)
-        ] as Array<UInt8>
+            r0,r1,r2,r3,
+            r4,r5,r6,r7,
+            r8,r9,r10,r11,
+            r12,r13,r14,r15] as Array<UInt8>
     }
 
     func decrypt(block: Array<UInt8>) -> Array<UInt8>? {

--- a/Sources/CryptoSwift/Generics.swift
+++ b/Sources/CryptoSwift/Generics.swift
@@ -20,7 +20,7 @@ extension UInt32: Initiable {}
 extension UInt64: Initiable {}
 
 /** build bit pattern from array of bits */
-@_specialize(UInt8)
+@_specialize(where T == UInt8)
 func integerFrom<T: UnsignedInteger>(_ bits: Array<Bit>) -> T {
     var bitPattern: T = 0
     for idx in bits.indices {

--- a/Sources/CryptoSwift/UInt16+Extension.swift
+++ b/Sources/CryptoSwift/UInt16+Extension.swift
@@ -9,12 +9,12 @@
 /** array of bytes */
 extension UInt16 {
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T) where T.Iterator.Element == UInt8, T.Index == Int {
         self = UInt16(bytes: bytes, fromIndex: bytes.startIndex)
     }
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T, fromIndex index: T.Index) where T.Iterator.Element == UInt8, T.Index == Int {
         let val0 = UInt16(bytes[index.advanced(by: 0)]) << 8
         let val1 = UInt16(bytes[index.advanced(by: 1)])

--- a/Sources/CryptoSwift/UInt32+Extension.swift
+++ b/Sources/CryptoSwift/UInt32+Extension.swift
@@ -18,12 +18,12 @@ extension UInt32: _UInt32Type {}
 /** array of bytes */
 extension UInt32 {
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T) where T.Iterator.Element == UInt8, T.Index == Int {
         self = UInt32(bytes: bytes, fromIndex: bytes.startIndex)
     }
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T, fromIndex index: T.Index) where T.Iterator.Element == UInt8, T.Index == Int {
         let val0 = UInt32(bytes[index.advanced(by: 0)]) << 24
         let val1 = UInt32(bytes[index.advanced(by: 1)]) << 16

--- a/Sources/CryptoSwift/UInt64+Extension.swift
+++ b/Sources/CryptoSwift/UInt64+Extension.swift
@@ -13,12 +13,12 @@ extension UInt64 {
 //        self = 0
 //    }
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T) where T.Iterator.Element == UInt8, T.IndexDistance == Int, T.Index == Int {
         self = UInt64(bytes: bytes, fromIndex: bytes.startIndex)
     }
 
-    @_specialize(ArraySlice<UInt8>)
+    @_specialize(where T == ArraySlice<UInt8>)
     init<T: Collection>(bytes: T, fromIndex index: T.Index) where T.Iterator.Element == UInt8, T.IndexDistance == Int, T.Index == Int {
         let val0 = UInt64(bytes[index.advanced(by: 0)]) << 56
         let val1 = UInt64(bytes[index.advanced(by: 1)]) << 48


### PR DESCRIPTION
This is some very lite change I've done to make CryptoSwift compile under the new Xcode and Swift 3.2 compiler. 