### PR TITLE
Fixed syntax error in Swift 4 podspec

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
   s.source_files  = "Sources/CryptoSwift/**/*.swift"
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0', 'SWIFT_OPTIMIZATION_LEVEL' = '-Owholemodule' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.0', 'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule' }
   s.requires_arc = true
 end


### PR DESCRIPTION
Changed '=' into '=>' for SWIFT_OPTIMIZATION_LEVEL option