### PR TITLE
Make Carthage cache work

### DIFF
--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -714,7 +714,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = CryptoSwift;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos watchos appletvsimulator watchsimulator";
-				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -770,7 +769,6 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = CryptoSwift;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos watchos appletvsimulator watchsimulator";
-				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
## What's in this pull request?
Update the project configurations for generating CryptoSwift-Swift.h to let Carthage know Swift version by which the framework is built.

## New folder structure of the built framework
<img width="229" alt="folderstructure of product" src="https://user-images.githubusercontent.com/10072745/28611254-74a635c8-71eb-11e7-9090-23de8a518ec0.png">

## Explanation and origin
#https://github.com/typelift/SwiftCheck/pull/227