### PR TITLE
Reduce expression complexity to appease compiler [Xcode 9]

### DIFF
--- a/Sources/CryptoSwift/AES.swift
+++ b/Sources/CryptoSwift/AES.swift
@@ -307,19 +307,14 @@ fileprivate extension AES {
         var rk2: Array<Array<UInt32>> = expandKey(key, variant: variant)
 
         for r in 1 ..< rounds {
-            var w: UInt32
-
-            w = rk2[r][0]
-            rk2[r][0] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
-
-            w = rk2[r][1]
-            rk2[r][1] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
-
-            w = rk2[r][2]
-            rk2[r][2] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
-
-            w = rk2[r][3]
-            rk2[r][3] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            for i in 0..<4 {
+                let w = rk2[r][i]
+                let u1 = U1[Int(B0(w))]
+                let u2 = U2[Int(B1(w))]
+                let u3 = U3[Int(B2(w))]
+                let u4 = U4[Int(B3(w))]
+                rk2[r][i] = u1^u2^u3^u4
+            }
         }
 
         return rk2

--- a/Sources/CryptoSwift/MD5.swift
+++ b/Sources/CryptoSwift/MD5.swift
@@ -101,10 +101,14 @@ public final class MD5: DigestType {
 
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15 and get M[g] value
             let gAdvanced = g << 2
-            var Mg = UInt32(chunk[chunk.startIndex &+ gAdvanced]) | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8 | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
-                Mg = Mg | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 3]) << 24
 
-            B = B &+ rotateLeft(A &+ F &+ k[j] &+ Mg, by: s[j])
+            let mg0 = UInt32(chunk[chunk.startIndex &+ gAdvanced])
+            let mg1 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8
+            let mg2 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
+            let mg3 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 3]) << 24
+            let mg = (mg0 | mg1 | mg2) | mg3
+
+            B = B &+ rotateLeft(A &+ F &+ k[j] &+ mg, by: s[j])
             A = dTemp
         }
 

--- a/Sources/CryptoSwift/MD5.swift
+++ b/Sources/CryptoSwift/MD5.swift
@@ -102,13 +102,13 @@ public final class MD5: DigestType {
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15 and get M[g] value
             let gAdvanced = g << 2
 
-            let mg0 = UInt32(chunk[chunk.startIndex &+ gAdvanced])
-            let mg1 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8
-            let mg2 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
-            let mg3 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 3]) << 24
-            let mg = (mg0 | mg1 | mg2) | mg3
+            let Mg0 = UInt32(chunk[chunk.startIndex &+ gAdvanced])
+            let Mg1 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8
+            let Mg2 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
+            let Mg3 = UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 3]) << 24
+            let Mg = (Mg0 | Mg1 | Mg2) | Mg3
 
-            B = B &+ rotateLeft(A &+ F &+ k[j] &+ mg, by: s[j])
+            B = B &+ rotateLeft(A &+ F &+ k[j] &+ Mg, by: s[j])
             A = dTemp
         }
 


### PR DESCRIPTION
This PR addresses a new issue in Xcode 9 Beta 5 (as well as existing issues #447, #418) where the compiler is unable to resolve certain expressions within a reasonable amount of time. The solution here, as before, is to break down these one-liners into multiple, simpler expressions.