### PR TITLE
Fixes an issue where the new Swift 4 compiler in Swift 3 compat mode

### DIFF
--- a/Sources/CryptoSwift/AES.swift
+++ b/Sources/CryptoSwift/AES.swift
@@ -308,18 +308,38 @@ fileprivate extension AES {
 
         for r in 1 ..< rounds {
             var w: UInt32
-
+            var b0: Int
+            var b1: Int
+            var b2: Int
+            var b3: Int
+            
             w = rk2[r][0]
-            rk2[r][0] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            b0 = Int(B0(w))
+            b1 = Int(B1(w))
+            b2 = Int(B2(w))
+            b3 = Int(B3(w))
+            rk2[r][0] = U1[b0] ^ U2[b1] ^ U3[b2] ^ U4[b3]
 
             w = rk2[r][1]
-            rk2[r][1] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            b0 = Int(B0(w))
+            b1 = Int(B1(w))
+            b2 = Int(B2(w))
+            b3 = Int(B3(w))
+            rk2[r][1] = U1[b0] ^ U2[b1] ^ U3[b2] ^ U4[b3]
 
             w = rk2[r][2]
-            rk2[r][2] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            b0 = Int(B0(w))
+            b1 = Int(B1(w))
+            b2 = Int(B2(w))
+            b3 = Int(B3(w))
+            rk2[r][2] = U1[b0] ^ U2[b1] ^ U3[b2] ^ U4[b3]
 
             w = rk2[r][3]
-            rk2[r][3] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            b0 = Int(B0(w))
+            b1 = Int(B1(w))
+            b2 = Int(B2(w))
+            b3 = Int(B3(w))
+            rk2[r][3] = U1[b0] ^ U2[b1] ^ U3[b2] ^ U4[b3]
         }
 
         return rk2

--- a/Sources/CryptoSwift/MD5.swift
+++ b/Sources/CryptoSwift/MD5.swift
@@ -101,7 +101,9 @@ public final class MD5: DigestType {
 
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15 and get M[g] value
             let gAdvanced = g << 2
-            var Mg = UInt32(chunk[chunk.startIndex &+ gAdvanced]) | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8 | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
+            var Mg = UInt32(chunk[chunk.startIndex &+ gAdvanced])
+                Mg = Mg | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 1]) << 8
+                Mg = Mg | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 2]) << 16
                 Mg = Mg | UInt32(chunk[chunk.startIndex &+ gAdvanced &+ 3]) << 24
 
             B = B &+ rotateLeft(A &+ F &+ k[j] &+ Mg, by: s[j])


### PR DESCRIPTION
Xcode 9.0 beta 5 (9M202q) ceases compiling due to solve complexity. This fixes the issue by splitting some complex lines into more (and easier to solve) lines.

The compiler error: "error: expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions"