### PR TITLE
Exposing very useful atomic extensions (bits, chunks, ...)

### DIFF
--- a/Sources/CryptoSwift/Array+Extension.swift
+++ b/Sources/CryptoSwift/Array+Extension.swift
@@ -16,7 +16,7 @@ extension Array {
 extension Array {
 
     /** split in chunks with given chunk size */
-    func chunks(size chunksize: Int) -> Array<Array<Element>> {
+    public func chunks(size chunksize: Int) -> Array<Array<Element>> {
         var words = Array<Array<Element>>()
         words.reserveCapacity(self.count / chunksize)
         for idx in stride(from: chunksize, through: self.count, by: chunksize) {

--- a/Sources/CryptoSwift/Bit.swift
+++ b/Sources/CryptoSwift/Bit.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Marcin Krzyzanowski. All rights reserved.
 //
 
-enum Bit: Int {
+public enum Bit: Int {
     case zero
     case one
 }

--- a/Sources/CryptoSwift/UInt8+Extension.swift
+++ b/Sources/CryptoSwift/UInt8+Extension.swift
@@ -43,7 +43,7 @@ extension UInt8 {
     }
 
     /** array of bits */
-    func bits() -> [Bit] {
+    public func bits() -> [Bit] {
         let totalBitsCount = MemoryLayout<UInt8>.size * 8
 
         var bitsArray = [Bit](repeating: Bit.zero, count: totalBitsCount)
@@ -59,7 +59,7 @@ extension UInt8 {
         return bitsArray
     }
 
-    func bits() -> String {
+    public func bits() -> String {
         var s = String()
         let arr: [Bit] = self.bits()
         for idx in arr.indices {


### PR DESCRIPTION
Hello there,

When trying to call bits() method on UInt8, an error is occuring at build time:
- "bits" is inaccessible due to "internal" protection level.

Marking this extension as **public** solves this error.
Also, marking chunk as public, since this is a 101 feature when working on Crypto.
Thank you for sharing this lib!!
Best,

Ludovic