### PR TITLE
Disabled code coverage for xCode 9

### DIFF
--- a/CryptoSwift.xcodeproj/xcshareddata/xcschemes/CryptoSwift.xcscheme
+++ b/CryptoSwift.xcodeproj/xcshareddata/xcschemes/CryptoSwift.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Cannot submit to app store if code coverage is enabled. This happens when using Carthage.

Code Coverage has been disabled

For more information please see:

https://github.com/Carthage/Carthage/issues/2056