### PR TITLE
Moves .characters.count to use string .count

### DIFF
--- a/Sources/CryptoSwift/CSArrayType+Extensions.swift
+++ b/Sources/CryptoSwift/CSArrayType+Extensions.swift
@@ -30,7 +30,7 @@ public extension CSArrayType where Iterator.Element == UInt8 {
     public func toHexString() -> String {
         return self.lazy.reduce("") {
             var s = String($1, radix: 16)
-            if s.characters.count == 1 {
+            if s.count == 1 {
                 s = "0" + s
             }
             return $0 + s


### PR DESCRIPTION
This will remove a warning that is showing when compiling with swift 3.2