### PR TITLE
Adds Carthage/Build into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ timeline.xctimeline
 
 /Framework
 .DS_Store
+Carthage/Build


### PR DESCRIPTION
Adds Carthage/Build into .gitignore to improve experience of using CryptoSwift with Carthage with its --use-submodules (which in the present state of CryptoSwift will lead to "modified files" inside the Carthage/Checkouts/CryptoSwift folder of a containing project when the containing Carthage checkout has been made with --use-submodules).