### PR TITLE
Update Swift Package Manager README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can use [Swift Package Manager](https://swift.org/package-manager/) and spec
 
 ```swift
 dependencies: [
-    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", majorVersion: 0)
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "0.8.0")
 ]
 ```
 
@@ -163,7 +163,7 @@ or more strict
 
 ```swift
 dependencies: [
-    .Package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", "0.7.2"),
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("0.8.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can use [Swift Package Manager](https://swift.org/package-manager/) and spec
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "0.8.0")
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "0.8.0"))
 ]
 ```
 


### PR DESCRIPTION
Change the installation instructions for the Swift Package Manager to support the latest Swift 4 API updates.

The `Package.Dependency` struct for Swift 4 is defined here: https://github.com/apple/swift-package-manager/blob/master/Sources/PackageDescription4/PackageDependency.swift