### PR TITLE
Remove deprecated 'characters'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode8
+osx_image: xcode9
 install:
     - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 script:

--- a/Sources/CryptoSwift/CSArrayType+Extensions.swift
+++ b/Sources/CryptoSwift/CSArrayType+Extensions.swift
@@ -30,7 +30,7 @@ public extension CSArrayType where Iterator.Element == UInt8 {
     public func toHexString() -> String {
         return self.lazy.reduce("") {
             var s = String($1, radix: 16)
-            if s.characters.count == 1 {
+            if s.utf8.count == 1 {
                 s = "0" + s
             }
             return $0 + s


### PR DESCRIPTION
Change string length to use utf8 length, rather than the deprecated characters variable.