### PR TITLE
Looks like processedBytesTotalCount is not necessary for update(withBytes:isLast:) for SHA3 calculation

### DIFF
--- a/Sources/CryptoSwift/SHA3.swift
+++ b/Sources/CryptoSwift/SHA3.swift
@@ -38,7 +38,6 @@ public final class SHA3: DigestType {
     public let markByte: UInt8
 
     fileprivate var accumulated = Array<UInt8>()
-    fileprivate var processedBytesTotalCount: Int = 0
     fileprivate var accumulatedHash: Array<UInt64>
 
     public enum Variant {
@@ -256,7 +255,7 @@ extension SHA3: Updatable {
 
         if isLast {
             // Add padding
-            let markByteIndex = processedBytesTotalCount &+ accumulated.count
+            let markByteIndex = accumulated.count
             if accumulated.count == 0 || accumulated.count % blockSize != 0 {
                 let r = blockSize * 8
                 let q = (r / 8) - (accumulated.count % (r / 8))
@@ -274,7 +273,6 @@ extension SHA3: Updatable {
             }
         }
         accumulated.removeFirst(processedBytes)
-        processedBytesTotalCount += processedBytes
 
         // TODO: verify performance, reduce vs for..in
         let result = accumulatedHash.reduce(Array<UInt8>()) { (result, value) -> Array<UInt8> in


### PR DESCRIPTION
Hi @krzyzanowskim, 

Thank you for open source this great library, it saved me a lot of time in my work. 

I'm not an expert on SHA3 hashing algorithm. But in my use, I accidentally find `processedBytesTotalCount` is not necessary for SHA3 calculation, and it even causes bug during calculation.

The scenario is like this:

I wanted to calculate file hash of a relative large binary. The quickest way was using `data.sha3(.sha256).toHexString()`, which actually calls `update(withBytes: data.bytes.slice, isLast: true)`. This will load the whole file data into memory. When the file is fairly large, like more than hundreds of bytes, calculate SHA3 will consume significant amount of memory.

So I decided to read the file chunk by chunk and iterate using `update(withBytes:isLast:)` to get the checksum. After some test, I found it will not get correct checksum, and it seems like a bug.

Here is my sample code:

```swift
// Sample file
let path = "/path/to/some/file"
// File size
let fileSize = try! FileManager.default.attributesOfItem(atPath: path)[FileAttributeKey.size] as! Int

let sha3Variant = SHA3.Variant.sha256
// SHA3 chunk size, code copied from library.
let chunkSize = (1600 - sha3Variant.outputLength * 2) / 8

// Use a fairly-sized chunk, in this case, 10240 times of SHA3 chunk, about 1.3 MB.
// The slice size should be integer-times of SHA3 chunk for correct padding.
let sliceSize = chunkSize * 1024 * 10
let sliceCount = Int(ceil(Double(fileSize) / Double(sliceSize)))
let remainderSize = fileSize % sliceSize

let sha3 = SHA3(variant: sha3Variant)
var out = [UInt8]()

// Start iterate.
var count = 0
let fp = fopen(path.cString(using: .utf8), "rb")
while count < sliceCount {
    let isLast = (count + 1) == sliceCount
    let fragmentSize = isLast ? remainderSize : sliceSize

    let ptr = UnsafeMutableRawPointer.allocate(bytes: fragmentSize, alignedTo: MemoryLayout<UInt8>.size)
    ptr.initializeMemory(as: UInt8.self, to: 0)
    fread(ptr, fragmentSize, 1, fp)

    let data = Data(bytes: ptr, count: fragmentSize).bytes
    out = try! sha3.update(withBytes: data[data.startIndex..<data.endIndex], isLast: isLast)
    count += 1
    ptr.deallocate(bytes: fragmentSize, alignedTo: MemoryLayout<UInt8>.size)
}
fclose(fp)

// Get result
let result1 = Data(bytes:out).toHexString()
print(result1)

// As a comparison, calculate SHA3 hash use default method.
let result2 = try! Data(contentsOf: URL(fileURLWithPath: path)).sha3(sha3Variant).toHexString()
print(result2)
```

After dig into source code, I found while padding the last chunk, `processedBytesTotalCount` actually lead to marking a wrong index. By removing `processedBytesTotalCount`, above code will get correct checksum, and of cause, iterate through large data file slice by slice saved a lot of memory.

Again, I'm not an expert on SHA3 (and other) hashing algorithm(s), maybe this is just a false alarm or my misunderstanding. Please look into it. Thank you.