### PR TITLE
Update swift_version to 4.1 for CryptoSwift.podspec

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.authors      = {'Marcin Krzyżanowski' => 'marcin@krzyzanowskim.com'}
   s.social_media_url   = "https://twitter.com/krzyzanowskim"
   s.cocoapods_version = '>= 1.4.0'
-  s.swift_version = "4.0"
+  s.swift_version = "4.1"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
   s.watchos.deployment_target = "2.0"


### PR DESCRIPTION
CryptoSwift 0.9.0 doesn't compile for projects still on Swift 4.0