### PR TITLE
More readable and less nesting in sha3

### DIFF
--- a/Sources/CryptoSwift/SHA3.swift
+++ b/Sources/CryptoSwift/SHA3.swift
@@ -176,6 +176,43 @@ public final class SHA3: DigestType {
     }
 
     fileprivate func process(block chunk: ArraySlice<UInt64>, currentHash hh: inout Array<UInt64>) {
+        
+        defer {
+            // Keccak-f
+            for round in 0..<24 {
+                θ(&hh)
+                
+                hh[1] = rotateLeft(hh[1], by: 1)
+                hh[2] = rotateLeft(hh[2], by: 62)
+                hh[3] = rotateLeft(hh[3], by: 28)
+                hh[4] = rotateLeft(hh[4], by: 27)
+                hh[5] = rotateLeft(hh[5], by: 36)
+                hh[6] = rotateLeft(hh[6], by: 44)
+                hh[7] = rotateLeft(hh[7], by: 6)
+                hh[8] = rotateLeft(hh[8], by: 55)
+                hh[9] = rotateLeft(hh[9], by: 20)
+                hh[10] = rotateLeft(hh[10], by: 3)
+                hh[11] = rotateLeft(hh[11], by: 10)
+                hh[12] = rotateLeft(hh[12], by: 43)
+                hh[13] = rotateLeft(hh[13], by: 25)
+                hh[14] = rotateLeft(hh[14], by: 39)
+                hh[15] = rotateLeft(hh[15], by: 41)
+                hh[16] = rotateLeft(hh[16], by: 45)
+                hh[17] = rotateLeft(hh[17], by: 15)
+                hh[18] = rotateLeft(hh[18], by: 21)
+                hh[19] = rotateLeft(hh[19], by: 8)
+                hh[20] = rotateLeft(hh[20], by: 18)
+                hh[21] = rotateLeft(hh[21], by: 2)
+                hh[22] = rotateLeft(hh[22], by: 61)
+                hh[23] = rotateLeft(hh[23], by: 56)
+                hh[24] = rotateLeft(hh[24], by: 14)
+                
+                π(&hh)
+                χ(&hh)
+                ι(&hh, round: round)
+            }
+        }
+        
         // expand
         hh[0] ^= chunk[0].littleEndian
         hh[1] ^= chunk[1].littleEndian
@@ -186,65 +223,31 @@ public final class SHA3: DigestType {
         hh[6] ^= chunk[6].littleEndian
         hh[7] ^= chunk[7].littleEndian
         hh[8] ^= chunk[8].littleEndian
-        if blockSize > 72 { // 72 / 8, sha-512
-            hh[9] ^= chunk[9].littleEndian
-            hh[10] ^= chunk[10].littleEndian
-            hh[11] ^= chunk[11].littleEndian
-            hh[12] ^= chunk[12].littleEndian
-            if blockSize > 104 { // 104 / 8, sha-384
-                hh[13] ^= chunk[13].littleEndian
-                hh[14] ^= chunk[14].littleEndian
-                hh[15] ^= chunk[15].littleEndian
-                hh[16] ^= chunk[16].littleEndian
-                if blockSize > 136 { // 136 / 8, sha-256
-                    hh[17] ^= chunk[17].littleEndian
-                    // FULL_SHA3_FAMILY_SUPPORT
-                    if blockSize > 144 { // 144 / 8, sha-224
-                        hh[18] ^= chunk[18].littleEndian
-                        hh[19] ^= chunk[19].littleEndian
-                        hh[20] ^= chunk[20].littleEndian
-                        hh[21] ^= chunk[21].littleEndian
-                        hh[22] ^= chunk[22].littleEndian
-                        hh[23] ^= chunk[23].littleEndian
-                        hh[24] ^= chunk[24].littleEndian
-                    }
-                }
-            }
-        }
-
-        // Keccak-f
-        for round in 0..<24 {
-            θ(&hh)
-
-            hh[1] = rotateLeft(hh[1], by: 1)
-            hh[2] = rotateLeft(hh[2], by: 62)
-            hh[3] = rotateLeft(hh[3], by: 28)
-            hh[4] = rotateLeft(hh[4], by: 27)
-            hh[5] = rotateLeft(hh[5], by: 36)
-            hh[6] = rotateLeft(hh[6], by: 44)
-            hh[7] = rotateLeft(hh[7], by: 6)
-            hh[8] = rotateLeft(hh[8], by: 55)
-            hh[9] = rotateLeft(hh[9], by: 20)
-            hh[10] = rotateLeft(hh[10], by: 3)
-            hh[11] = rotateLeft(hh[11], by: 10)
-            hh[12] = rotateLeft(hh[12], by: 43)
-            hh[13] = rotateLeft(hh[13], by: 25)
-            hh[14] = rotateLeft(hh[14], by: 39)
-            hh[15] = rotateLeft(hh[15], by: 41)
-            hh[16] = rotateLeft(hh[16], by: 45)
-            hh[17] = rotateLeft(hh[17], by: 15)
-            hh[18] = rotateLeft(hh[18], by: 21)
-            hh[19] = rotateLeft(hh[19], by: 8)
-            hh[20] = rotateLeft(hh[20], by: 18)
-            hh[21] = rotateLeft(hh[21], by: 2)
-            hh[22] = rotateLeft(hh[22], by: 61)
-            hh[23] = rotateLeft(hh[23], by: 56)
-            hh[24] = rotateLeft(hh[24], by: 14)
-
-            π(&hh)
-            χ(&hh)
-            ι(&hh, round: round)
-        }
+        
+        guard blockSize > 72 else { return }
+        hh[9] ^= chunk[9].littleEndian
+        hh[10] ^= chunk[10].littleEndian
+        hh[11] ^= chunk[11].littleEndian
+        hh[12] ^= chunk[12].littleEndian
+        
+        guard blockSize > 104 else { return }
+        hh[13] ^= chunk[13].littleEndian
+        hh[14] ^= chunk[14].littleEndian
+        hh[15] ^= chunk[15].littleEndian
+        hh[16] ^= chunk[16].littleEndian
+        
+        guard blockSize > 136 else { return }
+        hh[17] ^= chunk[17].littleEndian
+        
+        // FULL_SHA3_FAMILY_SUPPORT
+        guard blockSize > 144 else { return } // 144 / 8, sha-224
+        hh[18] ^= chunk[18].littleEndian
+        hh[19] ^= chunk[19].littleEndian
+        hh[20] ^= chunk[20].littleEndian
+        hh[21] ^= chunk[21].littleEndian
+        hh[22] ^= chunk[22].littleEndian
+        hh[23] ^= chunk[23].littleEndian
+        hh[24] ^= chunk[24].littleEndian
     }
 }
 
@@ -266,16 +269,15 @@ extension SHA3: Updatable {
         }
 
         var processedBytes = 0
-        for chunk in accumulated.batched(by: blockSize) {
-            if isLast || (accumulated.count - processedBytes) >= blockSize {
-                process(block: chunk.toUInt64Array().slice, currentHash: &accumulatedHash)
-                processedBytes += chunk.count
-            }
+        for chunk in accumulated.batched(by: blockSize) where isLast || (accumulated.count - processedBytes) >= blockSize {
+            process(block: chunk.toUInt64Array().slice, currentHash: &accumulatedHash)
+            processedBytes += chunk.count
         }
+        
         accumulated.removeFirst(processedBytes)
 
         // TODO: verify performance, reduce vs for..in
-        let result = accumulatedHash.reduce(Array<UInt8>()) { (result, value) -> Array<UInt8> in
+        let result = accumulatedHash.reduce(Array<UInt8>()) { (result, value) in
             return result + value.bigEndian.bytes()
         }
 

--- a/Sources/CryptoSwift/SHA3.swift
+++ b/Sources/CryptoSwift/SHA3.swift
@@ -224,19 +224,19 @@ public final class SHA3: DigestType {
         hh[7] ^= chunk[7].littleEndian
         hh[8] ^= chunk[8].littleEndian
         
-        guard blockSize > 72 else { return }
+        guard blockSize > 72 else { return } // 72 / 8, sha-512
         hh[9] ^= chunk[9].littleEndian
         hh[10] ^= chunk[10].littleEndian
         hh[11] ^= chunk[11].littleEndian
         hh[12] ^= chunk[12].littleEndian
         
-        guard blockSize > 104 else { return }
+        guard blockSize > 104 else { return } // 104 / 8, sha-384
         hh[13] ^= chunk[13].littleEndian
         hh[14] ^= chunk[14].littleEndian
         hh[15] ^= chunk[15].littleEndian
         hh[16] ^= chunk[16].littleEndian
         
-        guard blockSize > 136 else { return }
+        guard blockSize > 136 else { return } // 136 / 8, sha-256
         hh[17] ^= chunk[17].littleEndian
         
         // FULL_SHA3_FAMILY_SUPPORT


### PR DESCRIPTION
**What:**
This pr is refactoring some methods in `Sha3.swift` file to make it more readable and code looks more swifty.

**Why:**
Atm process method have a lot of nesting which is difficult to read.

Checklist:
- [x] Pull request against a `develop` branch.
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:
- 
- 
- 