### PR TITLE
use of blockmode changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Variant of AES encryption (AES-128, AES-192, AES-256) depends on given key lengt
 
 AES-256 example
 ```swift
-try AES(key: [1,2,3,...,32], blockMode: CBC(iv: [1,2,3,...,16]), padding: .pkcs7)
+try AES(key: [1,2,3,...,32], blockMode:BlockMode.CBC(iv: [1,2,3,...,16]), padding: .pkcs7)
 ```
 
 ###### All at once
@@ -407,8 +407,8 @@ let key: Array<UInt8> = [0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 let iv: Array<UInt8> = AES.randomIV(AES.blockSize)
 
 do {
-    let encrypted = try AES(key: key, blockMode: CBC(iv: iv), padding: .pkcs7).encrypt(input)
-    let decrypted = try AES(key: key, blockMode: CBC(iv: iv), padding: .pkcs7).decrypt(encrypted)
+     let encrypted = try AES(key: key, blockMode: BlockMode.CBC(iv: iv), padding: .pkcs7).encrypt(input)
+     let decrypted = try AES(key: key, blockMode: BlockMode.CBC(iv: iv), padding: .pkcs7).decrypt(encrypted)
 } catch {
     print(error)
 }    


### PR DESCRIPTION
AES(key: key, blockMode: BlockMode.CBC(iv: iv), padding: .pkcs7) I use  blockmode this way in swift 4.2.There are errors in use reaadme.

Fixes #

Checklist:
- [ ] Pull request against a `develop` branch.
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- 
- 
- 
