### PR TITLE
Correct count check for initializing UInt64 from Data

### DIFF
--- a/Sources/CryptoSwift/UInt64+Extension.swift
+++ b/Sources/CryptoSwift/UInt64+Extension.swift
@@ -30,13 +30,13 @@ extension UInt64 {
         let count = bytes.count
 
         let val0 = count > 0 ? UInt64(bytes[index.advanced(by: 0)]) << 56 : 0
-        let val1 = count > 0 ? UInt64(bytes[index.advanced(by: 1)]) << 48 : 0
-        let val2 = count > 0 ? UInt64(bytes[index.advanced(by: 2)]) << 40 : 0
-        let val3 = count > 0 ? UInt64(bytes[index.advanced(by: 3)]) << 32 : 0
-        let val4 = count > 0 ? UInt64(bytes[index.advanced(by: 4)]) << 24 : 0
-        let val5 = count > 0 ? UInt64(bytes[index.advanced(by: 5)]) << 16 : 0
-        let val6 = count > 0 ? UInt64(bytes[index.advanced(by: 6)]) << 8 : 0
-        let val7 = count > 0 ? UInt64(bytes[index.advanced(by: 7)]) : 0
+        let val1 = count > 1 ? UInt64(bytes[index.advanced(by: 1)]) << 48 : 0
+        let val2 = count > 2 ? UInt64(bytes[index.advanced(by: 2)]) << 40 : 0
+        let val3 = count > 3 ? UInt64(bytes[index.advanced(by: 3)]) << 32 : 0
+        let val4 = count > 4 ? UInt64(bytes[index.advanced(by: 4)]) << 24 : 0
+        let val5 = count > 5 ? UInt64(bytes[index.advanced(by: 5)]) << 16 : 0
+        let val6 = count > 6 ? UInt64(bytes[index.advanced(by: 6)]) << 8 : 0
+        let val7 = count > 7 ? UInt64(bytes[index.advanced(by: 7)]) : 0
 
         self = val0 | val1 | val2 | val3 | val4 | val5 | val6 | val7
     }


### PR DESCRIPTION
The current UInt64 initializer will crash when the collection contains fewer than 8 bytes due to a faulty count check.