### PR TITLE
Fix Swift 5 warning

### DIFF
--- a/Sources/CryptoSwift/Foundation/Data+Extension.swift
+++ b/Sources/CryptoSwift/Foundation/Data+Extension.swift
@@ -82,7 +82,7 @@ extension Data {
 
 extension Data {
     public init(hex: String) {
-        self.init(bytes: Array<UInt8>(hex: hex))
+        self.init(Array<UInt8>(hex: hex))
     }
 
     public var bytes: Array<UInt8> {


### PR DESCRIPTION
With Swift 5 the bytes initializer is deprecated. The replacement is
backwards compatible