### PR TITLE
Make bytesArray a 'let' constant

### DIFF
--- a/Sources/CryptoSwift/Foundation/Data+Extension.swift
+++ b/Sources/CryptoSwift/Foundation/Data+Extension.swift
@@ -19,7 +19,7 @@ extension Data {
     /// Two octet checksum as defined in RFC-4880. Sum of all octets, mod 65536
     public func checksum() -> UInt16 {
         var s: UInt32 = 0
-        var bytesArray = bytes
+        let bytesArray = bytes
         for i in 0 ..< bytesArray.count {
             s = s + UInt32(bytesArray[i])
         }


### PR DESCRIPTION
Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md) **-> not a new file**
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) **-> no need given the change, I guess**
- [ ] Tests added **-> not sure if it is relevant here ?**

Changes proposed in this pull request:
- change the 'var' variable `byteArray` to a 'let' constant to fix the following compiler warning : 

    > [...]/CryptoSwift/Sources/CryptoSwift/Foundation/Data+Extension.swift:22:13: Variable 'bytesArray' was never mutated; consider changing to 'let' constant

I have run the tests in Xcode and as far as I can tell everything seems fine (I am not an expert though).

By the way, I guessed I had to open Xcode and do Product > Test, but I think instructions about how to get coding and run the tests would be helpful for newcomers. From what I can tell there seems to be none at the moment.

Thanks to everyone who contributed to this great module!