### PR TITLE
Include minimum deployment targets in Swift 5 package

### DIFF
--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "CryptoSwift",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9),
+    ],
     products: [
         .library(
             name: "CryptoSwift",


### PR DESCRIPTION
CryptoSwift supports all the way back to iOS 8, macOS 10.10, and tvOS 9.