### PR TITLE
Changed access level to additional Array initializer 

### DIFF
--- a/Sources/CryptoSwift/Array+Extension.swift
+++ b/Sources/CryptoSwift/Array+Extension.swift
@@ -14,7 +14,7 @@
 //
 
 extension Array {
-    public init(reserveCapacity: Int) {
+    init(reserveCapacity: Int) {
         self = Array<Element>()
         self.reserveCapacity(reserveCapacity)
     }


### PR DESCRIPTION
This initializer is not a part of CryptoSwift business logic so it should not be public. Moreover it's used only internally in one place and it's not mentioned in documentation.

Story behind:
I was moving some macOS code to serverside and noticed code dependency to CryptoSwift in module which didn't have anything in common with encryption (but in general CryptoSwift was used in the project). Dependency was only on this extension and it was introduced accidentally (because XCode code suggestions).

Library API should be clean and contain only methods related to value delivered by it.