### PR TITLE
Use explicit UInt8 to fix compilation error on Linux and Swift 5.0

### DIFF
--- a/Sources/CryptoSwift/Cryptors.swift
+++ b/Sources/CryptoSwift/Cryptors.swift
@@ -37,6 +37,6 @@ extension Cryptors {
   /// Convenience helper that uses `Swift.RandomNumberGenerator`.
   /// - Parameter count: Length of array
     public static func randomIV(_ count: Int) -> Array<UInt8> {
-      (0..<count).map({ _ in .random(in: 0...UInt8.max) })
+      (0..<count).map({ _ in UInt8.random(in: 0...UInt8.max) })
     }
 }


### PR DESCRIPTION
(Potentially) fixes a compilation error when building on Linux with Swift 5.0:

```
/__w/1/s/.build/checkouts/CryptoSwift/Sources/CryptoSwift/Cryptors.swift:40:31: error: generic parameter 'Self' could not be inferred
      (0..<count).map({ _ in .random(in: 0...UInt8.max) })
                              ^
Swift.Comparable:2:24: note: in call to operator '...'
    public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self>
```

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- Use `UInt8.random` instead of `.random`
