### PR TITLE
Uses `reduce(into:,_)` instead of reduce(_,_)`

### DIFF
--- a/Sources/CryptoSwift/SHA3.swift
+++ b/Sources/CryptoSwift/SHA3.swift
@@ -275,8 +275,8 @@ extension SHA3: Updatable {
     self.accumulated.removeFirst(processedBytes)
 
     // TODO: verify performance, reduce vs for..in
-    let result = self.accumulatedHash.reduce(Array<UInt8>()) { (result, value) -> Array<UInt8> in
-      result + value.bigEndian.bytes()
+    let result = self.accumulatedHash.reduce(into: Array<UInt8>()) { (result, value) in
+      result += value.bigEndian.bytes()
     }
 
     // reset hash value for instance


### PR DESCRIPTION
Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
-One more place where  `reduce(_,_)` used changed for `reduce(into:,_)`

