### PR TITLE
Refactors Data.checksum() increasing performance 5 times

### DIFF
--- a/Sources/CryptoSwift/Foundation/Data+Extension.swift
+++ b/Sources/CryptoSwift/Foundation/Data+Extension.swift
@@ -18,13 +18,10 @@ import Foundation
 extension Data {
   /// Two octet checksum as defined in RFC-4880. Sum of all octets, mod 65536
   public func checksum() -> UInt16 {
-    var s: UInt32 = 0
-    let bytesArray = bytes
-    for i in 0 ..< bytesArray.count {
-      s = s + UInt32(bytesArray[i])
+    let s = self.withUnsafeBytes { buf in
+        return buf.lazy.map(UInt32.init).reduce(UInt32(0), +)
     }
-    s = s % 65536
-    return UInt16(s)
+    return UInt16(s % 65535)
   }
 
   public func md5() -> Data {

--- a/Tests/CryptoSwiftTests/DigestTests.swift
+++ b/Tests/CryptoSwiftTests/DigestTests.swift
@@ -220,6 +220,20 @@ final class DigestTests: XCTestCase {
     XCTAssert(data.checksum() == 0x96, "Invalid checksum")
   }
 
+  func testChecksumPerformance() {
+    let len = 1_000_000
+    let a = [UInt8](unsafeUninitializedCapacity: len) { buf, count in
+      for i in 0..<len {
+        buf[i] = UInt8.random(in: 0...UInt8.max)
+      }
+      count = len
+    }
+    let data: Data = Data(bytes: UnsafePointer<UInt8>(a), count: len)
+    self.measure {
+      _ = data.checksum()
+    }
+  }
+
   func testSHAPartialUpdates() {
     do {
       let testSize = 1024 * 1024 * 5


### PR DESCRIPTION
Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x ] Tests added.

Changes proposed in this pull request:
    Refactors Data.checksum() increasing performance 5 times.
    
    Tests on MacBook Pro 2018 (2,3 GHz Quad-Core Intel Core i5, RAM LPDDR3) show for data of random 1_000_000 bytes:
    * original implementation 0.586 sec
    * proposed implementation 0.126 sec
    * also tried `UInt16(bytes.lazy.map(UInt32.init).reduce(UInt32(0),+) % 65535)` which takes 0.417 sec
