### PR TITLE
Add ISO78164 padding

### DIFF
--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AF023D5230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */; };
+		0AF023D6230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */; };
+		0AF023D7230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */; };
+		0AF023D8230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */; };
+		0AF023D9230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */; };
 		0EE73E71204D598100110E11 /* CMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE73E70204D598100110E11 /* CMAC.swift */; };
 		0EE73E74204D59C200110E11 /* CMACTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE73E72204D599C00110E11 /* CMACTests.swift */; };
 		14156CE52011422400DDCFBC /* ChaCha20Poly1305Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14156CE42011422400DDCFBC /* ChaCha20Poly1305Tests.swift */; };
@@ -194,6 +199,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO78164Padding.swift; sourceTree = "<group>"; };
 		0EE73E70204D598100110E11 /* CMAC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMAC.swift; sourceTree = "<group>"; };
 		0EE73E72204D599C00110E11 /* CMACTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMACTests.swift; sourceTree = "<group>"; };
 		14156CE42011422400DDCFBC /* ChaCha20Poly1305Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaCha20Poly1305Tests.swift; sourceTree = "<group>"; };
@@ -508,6 +514,7 @@
 		75EC52371EE8B6CA0048EB3B /* CryptoSwift */ = {
 			isa = PBXGroup;
 			children = (
+				0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */,
 				7529366820683DFC00195874 /* AEAD */,
 				75EC52381EE8B6CA0048EB3B /* AES.swift */,
 				751EE9771F93996100161FFC /* AES.Cryptors.swift */,
@@ -821,6 +828,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0AF023D6230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				75211F95207249D8004E41F8 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -829,6 +837,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0AF023D5230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				75EC52861EE8B8170048EB3B /* CFB.swift in Sources */,
 				75EC52901EE8B81A0048EB3B /* Collection+Extension.swift in Sources */,
 				0EE73E71204D598100110E11 /* CMAC.swift in Sources */,
@@ -910,6 +919,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0AF023D7230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				75C2E76D1D55F097003D2BCA /* Access.swift in Sources */,
 				75482EA41CB310B7001F66A5 /* PBKDF.swift in Sources */,
 				758A94291A65C67400E46135 /* HMACTests.swift in Sources */,
@@ -940,6 +950,7 @@
 				7564F0552072EAEB00CA5A96 /* ExtensionsTestPerf.swift in Sources */,
 				7564F0562072EAEB00CA5A96 /* DigestTestsPerf.swift in Sources */,
 				81F279E22181F5C500449EDA /* ScryptTestsPerf.swift in Sources */,
+				0AF023D9230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				7564F0572072EAEB00CA5A96 /* TestsPerformance.swift in Sources */,
 				7564F0582072EAEB00CA5A96 /* AESTestsPerf.swift in Sources */,
 			);
@@ -955,6 +966,7 @@
 				7595C15C2072E5B900EA1A5F /* ExtensionsTestPerf.swift in Sources */,
 				7595C1582072E5B900EA1A5F /* DigestTestsPerf.swift in Sources */,
 				81F279E12181F5C500449EDA /* ScryptTestsPerf.swift in Sources */,
+				0AF023D8230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				7595C14D2072E48C00EA1A5F /* TestsPerformance.swift in Sources */,
 				7595C1592072E5B900EA1A5F /* AESTestsPerf.swift in Sources */,
 			);

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Good mood
   PKCS#5
 | [PKCS#7](http://tools.ietf.org/html/rfc5652#section-6.3)
 | [Zero padding](https://en.wikipedia.org/wiki/Padding_(cryptography)#Zero_padding)
+| [ISO78164](http://www.embedx.com/pdfs/ISO_STD_7816/info_isoiec7816-4%7Bed21.0%7Den.pdf)
 | No padding
 
 #### Authenticated Encryption with Associated Data (AEAD)

--- a/Sources/CryptoSwift/ISO78164Padding.swift
+++ b/Sources/CryptoSwift/ISO78164Padding.swift
@@ -1,0 +1,42 @@
+//
+//  CryptoSwift
+//
+//  Copyright (C) Marcin Krzyżanowski <marcin@krzyzanowskim.com>
+//  This software is provided 'as-is', without any express or implied warranty.
+//
+//  In no event will the authors be held liable for any damages arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  - The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation is required.
+//  - Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//  - This notice may not be removed or altered from any source or binary distribution.
+//
+
+import Foundation
+
+// First byte is 0x80, rest is zero padding
+// http://www.crypto-it.net/eng/theory/padding.html
+// http://www.embedx.com/pdfs/ISO_STD_7816/info_isoiec7816-4%7Bed21.0%7Den.pdf
+struct ISO78164Padding: PaddingProtocol {
+  init() {
+  }
+
+  func add(to bytes: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
+    var padded = Array(bytes)
+    padded.append(0x80)
+
+    while (padded.count % blockSize) != 0 {
+      padded.append(0x00)
+    }
+    return padded
+  }
+
+  func remove(from bytes: Array<UInt8>, blockSize _: Int?) -> Array<UInt8> {
+    if let idx = bytes.lastIndex(of: 0x80) {
+      return Array(bytes[..<idx])
+    } else {
+      return bytes
+    }
+  }
+}

--- a/Sources/CryptoSwift/Padding.swift
+++ b/Sources/CryptoSwift/Padding.swift
@@ -19,7 +19,7 @@ public protocol PaddingProtocol {
 }
 
 public enum Padding: PaddingProtocol {
-  case noPadding, zeroPadding, pkcs7, pkcs5
+  case noPadding, zeroPadding, pkcs7, pkcs5, iso78164
 
   public func add(to: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
     switch self {
@@ -31,6 +31,8 @@ public enum Padding: PaddingProtocol {
         return PKCS7.Padding().add(to: to, blockSize: blockSize)
       case .pkcs5:
         return PKCS5.Padding().add(to: to, blockSize: blockSize)
+      case .iso78164:
+        return ISO78164Padding().add(to: to, blockSize: blockSize)
     }
   }
 
@@ -44,6 +46,8 @@ public enum Padding: PaddingProtocol {
         return PKCS7.Padding().remove(from: from, blockSize: blockSize)
       case .pkcs5:
         return PKCS5.Padding().remove(from: from, blockSize: blockSize)
+      case .iso78164:
+        return ISO78164Padding().remove(from: from, blockSize: blockSize)
     }
   }
 }

--- a/Tests/CryptoSwiftTests/PaddingTests.swift
+++ b/Tests/CryptoSwiftTests/PaddingTests.swift
@@ -60,11 +60,41 @@ final class PaddingTests: XCTestCase {
     XCTAssertEqual(padding.remove(from: padding.add(to: input, blockSize: 16), blockSize: 16), input, "ZeroPadding failed")
   }
 
+  func testISO78164_0() {
+    let input: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0x80]
+    let expected: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0x80, 0x80]
+    let padded = ISO78164Padding().add(to: input, blockSize: 16)
+    XCTAssertEqual(padded, expected, "ISO78164 failed")
+    let clean =  ISO78164Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO78164 failed")
+  }
+
+  func testISO78164_1() {
+    let input: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 0]
+    let expected: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 0, 0x80] + [UInt8](repeating: UInt8(0), count: 15)
+    let padded =  ISO78164Padding().add(to: input, blockSize: 16)
+    XCTAssertEqual(padded, expected, "ISO78164 failed")
+    let clean =  ISO78164Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO78164 failed")
+  }
+
+  func testISO78164_2() {
+    let input: Array<UInt8> = []
+    let expected: Array<UInt8> = [0x80] + [UInt8](repeating: UInt8(0), count: 15)
+    let padded =  ISO78164Padding().add(to: input, blockSize: 16)
+    XCTAssertEqual(padded, expected, "ISO78164 failed")
+    let clean =  ISO78164Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO78164 failed")
+  }
+
   static let allTests = [
     ("testPKCS7_0", testPKCS7_0),
     ("testPKCS7_1", testPKCS7_1),
     ("testPKCS7_2", testPKCS7_2),
     ("testZeroPadding1", testZeroPadding1),
-    ("testZeroPadding2", testZeroPadding2)
+    ("testZeroPadding2", testZeroPadding2),
+    ("testISO78164_0", testISO78164_0),
+    ("testISO78164_1", testISO78164_1),
+    ("testISO78164_2", testISO78164_2)
   ]
 }


### PR DESCRIPTION
Fixes #
- New feature added

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:
- ISO78164 padding is added (used in JavaCard applications)

-------
Motivation: this padding scheme is often used in JavaCard applications. As iOS 13 enables NFC communication with JavaCards over the ISO interface the iOS apps may need this padding to implement secure channels with the JavaCards correctly (I have this need in my project).

This is WIP PR, mainly to get an idea whether you agree with adding a new padding scheme and to figure out whether the implementation is OK (e.g., enum extension is OK).

If you agree with the merge, I will finish the checklist. 

Thanks!
