### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Run `carthage` to build the framework and drag the built CryptoSwift.framework i
 You can use [Swift Package Manager](https://swift.org/package-manager/) and specify dependency in `Package.swift` by adding this:
 
 ```swift
-.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.0"))
+.package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.3.1"))
 ```
 
 See: [Package.swift - manual](http://blog.krzyzanowskim.com/2016/08/09/package-swift-manual/)


### PR DESCRIPTION
SwiftPM isn't able to resolve `.upToNextMinor(from: "1.0")`, I get a build error when trying this. So updating it to `.upToNextMinor(from: "1.3.1")` to keep README up to date.

Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
-
