### PR TITLE
Update iOS platform to 9 to get rid of build warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "CryptoSwift",
   platforms: [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9)
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9)
   ],
   products: [
     .library(


### PR DESCRIPTION
I am getting the following warning building CryptoSwift via Swift Package:

"The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET'
 is set to 8.0, but the range of supported deployment target versions
 is 9.0 to 14.0.99."

PR #827 did not fix this for me.

Changes proposed in this pull request:
- Update Package.swift iOS platform from v8 to v9

I have tested this; it fixes the issue for me.