### PR TITLE
Support watchos in spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "CryptoSwift",
   platforms: [
-    .macOS(.v10_12), .iOS(.v9), .tvOS(.v9)
+    .macOS(.v10_12), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
   ],
   products: [
     .library(


### PR DESCRIPTION
The [podspec](https://github.com/krzyzanowskim/CryptoSwift/blob/1adeed4bc54f2b3e5feba2af2a55a3cac5c9737f/CryptoSwift.podspec#L15) supports watchos, but the spm metadata doesn't.