### PR TITLE
Implement ISO10126 Padding

### DIFF
--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		14156CE52011422400DDCFBC /* ChaCha20Poly1305Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14156CE42011422400DDCFBC /* ChaCha20Poly1305Tests.swift */; };
 		1467460F2017BB3600DF04ED /* AEAD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1467460E2017BB3600DF04ED /* AEAD.swift */; };
 		35F3E51C23BF9A6700A024A1 /* OCB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F3E51B23BF9A6700A024A1 /* OCB.swift */; };
+		42012783267A6F1C00F82506 /* ISO10126Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42012782267A6F1C00F82506 /* ISO10126Padding.swift */; };
 		674A736F1BF5D85B00866C5B /* RabbitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674A736E1BF5D85B00866C5B /* RabbitTests.swift */; };
 		750509991F6BEF2A00394A1B /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750509981F6BEF2A00394A1B /* PKCS7.swift */; };
 		750CC3EB1DC0CACE0096BE6E /* BlowfishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750CC3EA1DC0CACE0096BE6E /* BlowfishTests.swift */; };
@@ -204,6 +205,7 @@
 		1467460E2017BB3600DF04ED /* AEAD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEAD.swift; sourceTree = "<group>"; };
 		35F3E51B23BF9A6700A024A1 /* OCB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCB.swift; sourceTree = "<group>"; };
 		35F3E51D23BF9AD300A024A1 /* AESOCBTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AESOCBTests.swift; sourceTree = "<group>"; };
+		42012782267A6F1C00F82506 /* ISO10126Padding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO10126Padding.swift; sourceTree = "<group>"; };
 		674A736E1BF5D85B00866C5B /* RabbitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RabbitTests.swift; sourceTree = "<group>"; };
 		750509981F6BEF2A00394A1B /* PKCS7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCS7.swift; sourceTree = "<group>"; };
 		750CC3EA1DC0CACE0096BE6E /* BlowfishTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlowfishTests.swift; sourceTree = "<group>"; };
@@ -509,6 +511,7 @@
 			isa = PBXGroup;
 			children = (
 				0AF023D4230F2B0F008E4E68 /* ISO78164Padding.swift */,
+				42012782267A6F1C00F82506 /* ISO10126Padding.swift */,
 				7529366820683DFC00195874 /* AEAD */,
 				75EC52381EE8B6CA0048EB3B /* AES.swift */,
 				751EE9771F93996100161FFC /* AES.Cryptors.swift */,
@@ -831,6 +834,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				42012783267A6F1C00F82506 /* ISO10126Padding.swift in Sources */,
 				0AF023D5230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
 				75EC52861EE8B8170048EB3B /* CFB.swift in Sources */,
 				75EC52901EE8B81A0048EB3B /* Collection+Extension.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Good mood
 | [PKCS#7](http://tools.ietf.org/html/rfc5652#section-6.3)
 | [Zero padding](https://en.wikipedia.org/wiki/Padding_(cryptography)#Zero_padding)
 | [ISO78164](http://www.embedx.com/pdfs/ISO_STD_7816/info_isoiec7816-4%7Bed21.0%7Den.pdf)
+| [ISO10126](https://en.wikipedia.org/wiki/Padding_(cryptography)#ISO_10126)
 | No padding
 
 #### Authenticated Encryption with Associated Data (AEAD)

--- a/Sources/CryptoSwift/ISO10126Padding.swift
+++ b/Sources/CryptoSwift/ISO10126Padding.swift
@@ -1,0 +1,56 @@
+//
+//  CryptoSwift
+//
+//  Copyright (C) Marcin Krzyżanowski <marcin@krzyzanowskim.com>
+//  This software is provided 'as-is', without any express or implied warranty.
+//
+//  In no event will the authors be held liable for any damages arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  - The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation is required.
+//  - Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+//  - This notice may not be removed or altered from any source or binary distribution.
+//
+
+import Foundation
+
+/// Padding with random bytes, ending with the number of added bytes.
+/// Read the [Wikipedia](https://en.wikipedia.org/wiki/Padding_(cryptography)#ISO_10126)
+/// and [Crypto-IT](http://www.crypto-it.net/eng/theory/padding.html) articles for more info.
+struct ISO10126Padding: PaddingProtocol {
+  init() {
+  }
+
+  @inlinable
+  func add(to bytes: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
+    let padding = UInt8(blockSize - (bytes.count % blockSize))
+    var withPadding = bytes
+    if padding > 0 {
+      withPadding += (0..<(padding - 1)).map { _ in UInt8(arc4random() % 254 + 1) } + [padding]
+    }
+    return withPadding
+  }
+
+  @inlinable
+  func remove(from bytes: Array<UInt8>, blockSize: Int?) -> Array<UInt8> {
+    guard !bytes.isEmpty, let lastByte = bytes.last else {
+      return bytes
+    }
+
+    assert(!bytes.isEmpty, "Need bytes to remove padding")
+
+    let padding = Int(lastByte) // last byte
+    let finalLength = bytes.count - padding
+
+    if finalLength < 0 {
+      return bytes
+    }
+
+    if padding >= 1 {
+      return Array(bytes[0..<finalLength])
+    }
+
+    return bytes
+  }
+}

--- a/Sources/CryptoSwift/Padding.swift
+++ b/Sources/CryptoSwift/Padding.swift
@@ -19,7 +19,7 @@ public protocol PaddingProtocol {
 }
 
 public enum Padding: PaddingProtocol {
-  case noPadding, zeroPadding, pkcs7, pkcs5, iso78164
+  case noPadding, zeroPadding, pkcs7, pkcs5, iso78164, iso10126
 
   public func add(to: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
     switch self {
@@ -33,6 +33,8 @@ public enum Padding: PaddingProtocol {
         return PKCS5.Padding().add(to: to, blockSize: blockSize)
       case .iso78164:
         return ISO78164Padding().add(to: to, blockSize: blockSize)
+      case .iso10126:
+        return ISO10126Padding().add(to: to, blockSize: blockSize)
     }
   }
 
@@ -48,6 +50,8 @@ public enum Padding: PaddingProtocol {
         return PKCS5.Padding().remove(from: from, blockSize: blockSize)
       case .iso78164:
         return ISO78164Padding().remove(from: from, blockSize: blockSize)
+      case .iso10126:
+        return ISO10126Padding().remove(from: from, blockSize: blockSize)
     }
   }
 }

--- a/Tests/CryptoSwiftTests/PaddingTests.swift
+++ b/Tests/CryptoSwiftTests/PaddingTests.swift
@@ -87,6 +87,36 @@ final class PaddingTests: XCTestCase {
     XCTAssertEqual(clean, input, "ISO78164 failed")
   }
 
+  func testISO10126_0() {
+    let input: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3]
+    let padded = ISO10126Padding().add(to: input, blockSize: 16)
+    XCTAssertTrue(padded.starts(with: input), "ISO10126 failed")
+    XCTAssertEqual(padded.last, 3, "ISO10126 failed")
+    XCTAssertEqual(padded.count, 16)
+    let clean = ISO10126Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO10126 failed")
+  }
+
+  func testISO10126_1() {
+    let input: Array<UInt8> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6]
+    let padded = ISO10126Padding().add(to: input, blockSize: 16)
+    XCTAssertTrue(padded.starts(with: input), "ISO10126 failed")
+    XCTAssertEqual(padded.last, 16, "ISO10126 failed")
+    XCTAssertEqual(padded.count, 32)
+    let clean = ISO10126Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO10126 failed")
+  }
+
+  func testISO10126_2() {
+    let input: Array<UInt8> = []
+    let padded = ISO10126Padding().add(to: input, blockSize: 16)
+    XCTAssertTrue(padded.starts(with: input), "ISO10126 failed")
+    XCTAssertEqual(padded.last, 16, "ISO10126 failed")
+    XCTAssertEqual(padded.count, 16)
+    let clean = ISO10126Padding().remove(from: padded, blockSize: nil)
+    XCTAssertEqual(clean, input, "ISO10126 failed")
+  }
+
   static let allTests = [
     ("testPKCS7_0", testPKCS7_0),
     ("testPKCS7_1", testPKCS7_1),
@@ -95,6 +125,9 @@ final class PaddingTests: XCTestCase {
     ("testZeroPadding2", testZeroPadding2),
     ("testISO78164_0", testISO78164_0),
     ("testISO78164_1", testISO78164_1),
-    ("testISO78164_2", testISO78164_2)
+    ("testISO78164_2", testISO78164_2),
+    ("testISO10126_0", testISO10126_0),
+    ("testISO10126_1", testISO10126_1),
+    ("testISO10126_2", testISO10126_2)
   ]
 }


### PR DESCRIPTION
Fixes #

- New feature added

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:

- Implementing ISO 10126 Padding

Motivation: This padding scheme is widely used today by many cryptographic algorithms, and is implemented by major libraries such as [Bouncy Castle](https://github.com/bcgit/bc-java) and [Spongy Castle](https://github.com/rtyley/spongycastle).
On Wikipedia, it is (quite wrongly) stated that this padding scheme has been withdrawn. As per this [thread](http://bouncy-castle.1462172.n4.nabble.com/ISO10126-Padding-Withdrawn-td4419001.html), the standards where this padding scheme was first descried ([10126-1](https://www.iso.org/standard/18113.html) and [10126-2](https://www.iso.org/standard/18114.html)) were indeed withdrawn, but not the actual padding scheme itself.
