### PR TITLE
Fix arc4random Linux compatibility

### DIFF
--- a/Sources/CryptoSwift/ISO10126Padding.swift
+++ b/Sources/CryptoSwift/ISO10126Padding.swift
@@ -27,7 +27,7 @@ struct ISO10126Padding: PaddingProtocol {
     let padding = UInt8(blockSize - (bytes.count % blockSize))
     var withPadding = bytes
     if padding > 0 {
-      withPadding += (0..<(padding - 1)).map { _ in UInt8(arc4random() % 254 + 1) } + [padding]
+      withPadding += (0..<(padding - 1)).map { _ in UInt8.random(in: 0...255) } + [padding]
     }
     return withPadding
   }


### PR DESCRIPTION
Fixes #

- Build issues on Linux due to missing arc4random function

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:

- Use the Swift built-in `random(in:)` function. This is the new suggested way of generating random numbers since Swift 4.2.

The issue is that `arc4random` is not present on all Linux distributions.
