### PR TITLE
Use BlockCipher.blockSize as a result length in randomIV helper

### DIFF
--- a/Sources/CryptoSwift/BlockCipher.swift
+++ b/Sources/CryptoSwift/BlockCipher.swift
@@ -13,6 +13,6 @@
 //  - This notice may not be removed or altered from any source or binary distribution.
 //
 
-protocol BlockCipher: Cipher {
+public protocol BlockCipher: Cipher {
   static var blockSize: Int { get }
 }

--- a/Sources/CryptoSwift/Cryptors.swift
+++ b/Sources/CryptoSwift/Cryptors.swift
@@ -29,16 +29,12 @@ public protocol Cryptors: AnyObject {
 
   /// Cryptor suitable for decryption
   func makeDecryptor() throws -> Cryptor & Updatable
-
-  /// Generate array of random bytes. Helper function.
-  static func randomIV(_ blockSize: Int) -> Array<UInt8>
 }
 
-extension Cryptors {
-  /// Generate array of random values.
-  /// Convenience helper that uses `Swift.RandomNumberGenerator`.
-  /// - Parameter count: Length of array
-  public static func randomIV(_ count: Int) -> Array<UInt8> {
-    (0..<count).map({ _ in UInt8.random(in: 0...UInt8.max) })
+public extension Cryptors where Self: BlockCipher {
+  /// Generates array of random bytes. `blockSize` is used as length of the result array.
+  /// Convenience helper that uses `Swift.SystemRandomNumberGenerator`.
+  static func randomIV() -> [UInt8] {
+    (0..<Self.blockSize).map({ _ in UInt8.random(in: 0...UInt8.max) })
   }
 }

--- a/Tests/CryptoSwiftTests/AESTests.swift
+++ b/Tests/CryptoSwiftTests/AESTests.swift
@@ -345,6 +345,11 @@ final class AESTests: XCTestCase {
     }
   }
 
+  func testAESRandomIV() {
+    let iv = AES.randomIV()
+    XCTAssertEqual(iv.count, AES.blockSize)
+  }
+
   func testAESWithWrongKey() {
     let key: Array<UInt8> = [0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c]
     let key2: Array<UInt8> = [0x22, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x33]
@@ -678,6 +683,7 @@ extension AESTests {
       ("testAESDecryptCTRSeek", testAESDecryptCTRSeek),
       ("testAESEncryptCTRIrregularLengthIncrementalUpdate", testAESEncryptCTRIrregularLengthIncrementalUpdate),
       ("testAESEncryptCTRStream", testAESEncryptCTRStream),
+      ("testAESRandomIV", testAESRandomIV),
       ("testIssue298", testIssue298),
       ("testIssue394", testIssue394),
       ("testIssue411", testIssue411),

--- a/Tests/CryptoSwiftTests/Access.swift
+++ b/Tests/CryptoSwiftTests/Access.swift
@@ -29,8 +29,8 @@ class Access: XCTestCase {
   }
 
   func testRandomIV() {
-    _ = AES.randomIV(AES.blockSize)
-    _ = ChaCha20.randomIV(ChaCha20.blockSize)
+    _ = AES.randomIV()
+    _ = ChaCha20.randomIV()
   }
 
   func testDigest() {

--- a/Tests/CryptoSwiftTests/ChaCha20Tests.swift
+++ b/Tests/CryptoSwiftTests/ChaCha20Tests.swift
@@ -106,6 +106,11 @@ final class ChaCha20Tests: XCTestCase {
       XCTFail()
     }
   }
+
+  func testChaCha20RandomIV() {
+    let iv = ChaCha20.randomIV()
+    XCTAssertEqual(iv.count, ChaCha20.blockSize)
+  }
 }
 
 extension ChaCha20Tests {
@@ -114,7 +119,8 @@ extension ChaCha20Tests {
       ("testChaCha20", testChaCha20),
       ("testCore", testCore),
       ("testVector1Py", testVector1Py),
-      ("testChaCha20EncryptPartial", testChaCha20EncryptPartial)
+      ("testChaCha20EncryptPartial", testChaCha20EncryptPartial),
+      ("testChaCha20RandomIV", testChaCha20RandomIV)
     ]
 
     return tests


### PR DESCRIPTION
#### Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md) (not needed).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

#### Changes proposed in this pull request:
Use `BlockCipher.blockSize` as a result length in `randomIV` helper. This should help to avoid two mistakes when `randomIV` helper is used:
* Passing of invalid array length for IV generation.
* Usage of `randomIV` helper for a **key** generation. Because it uses `Swift.SystemRandomNumberGenerator`, depending on the platform the result [might be not](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator#3022414) cryptographically secure to be used as a key. [`Security.SecRandomCopyBytes`](https://developer.apple.com/documentation/security/randomization_services) should be preferred to generate a key on Apple platforms.