### PR TITLE
Fix Xcode 13.3.1 Cycle error

### DIFF
--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -731,9 +731,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 754BE46B19693E190098E6F3 /* Build configuration list for PBXNativeTarget "CryptoSwift" */;
 			buildPhases = (
+				754BE45219693E190098E6F3 /* Headers */,
 				754BE45019693E190098E6F3 /* Sources */,
 				754BE45119693E190098E6F3 /* Frameworks */,
-				754BE45219693E190098E6F3 /* Headers */,
 				754BE45319693E190098E6F3 /* Resources */,
 				75B601E0197D69770009B53D /* CopyFiles */,
 			);


### PR DESCRIPTION
Changes proposed in this pull request:
- When using CryptoSwift as a dependency for frameworks with Xcode 13.3.1 we can observe the following error:

```
error: Cycle inside CryptoSwift; building could produce unreliable results. This usually can be resolved by moving the target's Headers build phase before Compile Sources.
```

This PR fixes this compilation issue by updating the Build Phases and setting the Headers compilation before the Sources compilation.

This problem seems to be linked to the following bug report: https://developer.apple.com/forums/thread/700997