### PR TITLE
Fixing branch name in workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,9 +2,9 @@ name: Linux
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,9 +2,9 @@ name: macOS
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer


### PR DESCRIPTION
Changes proposed in this pull request:
- The branch `master` was renamed to `main`, but workflows were not updated, so checks were not running for PRs.