### PR TITLE
ChaCha20 Explicitly Set Counter

### DIFF
--- a/Sources/CryptoSwift/ChaCha20.swift
+++ b/Sources/CryptoSwift/ChaCha20.swift
@@ -28,8 +28,8 @@ public final class ChaCha20: BlockCipher {
   fileprivate let key: Key
   fileprivate var counter: Array<UInt8>
 
-  public init(key: Array<UInt8>, iv nonce: Array<UInt8>) throws {
-    precondition(nonce.count == 12 || nonce.count == 8)
+  public init(key: Array<UInt8>, counter: Array<UInt8> = [0, 0, 0, 0], iv nonce: Array<UInt8>) throws {
+    precondition(counter.count == 4 && (nonce.count == 12 || nonce.count == 8))
 
     if key.count != 32 {
       throw Error.invalidKeyOrInitializationVector
@@ -39,9 +39,11 @@ public final class ChaCha20: BlockCipher {
     self.keySize = self.key.count
 
     if nonce.count == 8 {
-      self.counter = [0, 0, 0, 0, 0, 0, 0, 0] + nonce
+      self.counter = counter + [0, 0, 0, 0] + nonce
+    } else if nonce.count == 12 {
+      self.counter = counter + nonce
     } else {
-      self.counter = [0, 0, 0, 0] + nonce
+      throw Error.invalidKeyOrInitializationVector
     }
 
     assert(self.counter.count == 16)

--- a/Tests/CryptoSwiftTests/ChaCha20Tests.swift
+++ b/Tests/CryptoSwiftTests/ChaCha20Tests.swift
@@ -106,6 +106,36 @@ final class ChaCha20Tests: XCTestCase {
       XCTFail()
     }
   }
+
+  /// Test Vector - https://datatracker.ietf.org/doc/html/rfc9001#name-chacha20-poly1305-short-hea
+  func testChaCha20ExplicitCounterV1() {
+    let hpKey = Array(hex: "0x25a282b9e82f06f21f488917a4fc8f1b73573685608597d0efcb076b0ab7a7a4")
+    /// Sample = 0x5e5cd55c41f69080575d7999c25a5bfb
+    let counter = Array(hex: "0x5e5cd55c")
+    let iv = Array(hex: "0x41f69080575d7999c25a5bfb")
+
+    do {
+      let mask = try CryptoSwift.ChaCha20(key: hpKey, counter: counter, iv: iv).encrypt(Array<UInt8>(repeating: 0, count: 5))
+      XCTAssertEqual(mask, Array(hex: "0xaefefe7d03"))
+    } catch {
+      XCTFail("\(error)")
+    }
+  }
+
+  /// Test Vector - https://www.ietf.org/archive/id/draft-ietf-quic-v2-10.html#name-chacha20-poly1305-short-head
+  func testChaCha20ExplicitCounterV2() {
+    let hpKey = Array(hex: "0xd659760d2ba434a226fd37b35c69e2da8211d10c4f12538787d65645d5d1b8e2")
+    /// Sample = 0xe7b6b932bc27d786f4bc2bb20f2162ba
+    let counter = Array(hex: "0xe7b6b932")
+    let iv = Array(hex: "0xbc27d786f4bc2bb20f2162ba")
+
+    do {
+      let mask = try CryptoSwift.ChaCha20(key: hpKey, counter: counter, iv: iv).encrypt(Array<UInt8>(repeating: 0, count: 5))
+      XCTAssertEqual(mask, Array(hex: "0x97580e32bf"))
+    } catch {
+      XCTFail("\(error)")
+    }
+  }
 }
 
 extension ChaCha20Tests {
@@ -114,7 +144,9 @@ extension ChaCha20Tests {
       ("testChaCha20", testChaCha20),
       ("testCore", testCore),
       ("testVector1Py", testVector1Py),
-      ("testChaCha20EncryptPartial", testChaCha20EncryptPartial)
+      ("testChaCha20EncryptPartial", testChaCha20EncryptPartial),
+      ("testChaCha20ExplicitCounterV1", testChaCha20ExplicitCounterV1),
+      ("testChaCha20ExplicitCounterV2", testChaCha20ExplicitCounterV2)
     ]
 
     return tests


### PR DESCRIPTION
 Feature: Set Counter in ChaCha20 Cipher's Initializer

 Checklist:
 - [x] Correct file headers (see CONTRIBUTING.md).
 - [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
 - [x] Tests added.

 Changes proposed in this pull request:
 Are there any reasons, security or otherwise, that the leading 4 bytes in the `ChaCha20` Cipher's `counter` param can't be explicitly set to something other than `[0, 0, 0, 0]`?

 I'm trying to generate a QUIC header protection mask ([as discussed in RFC 9001 - section 5.4.4](https://datatracker.ietf.org/doc/html/rfc9001#section-5.4.4)) and it requires the 4 byte prefix in the `counter` to be explicitly set upon the cipher's initialization.

 The change proposed in this PR is to add a `counter` param to the ChaCha20 initializer that defaults to the standard 4 zero bytes. The default value prevents breaking changes while keeping only a single initializer. I also wasn't sure what API would be preferable...

 1) Default `counter` param in the current initializer (this way the user knows for sure they're setting the counter).
 ```swift
 public init(key: Array<UInt8>, counter: Array<UInt8> = [0, 0, 0, 0], iv nonce: Array<UInt8>) throws {
     precondition(counter.count == 4 && (nonce.count == 12 || nonce.count == 8))
     ...
 }
 ```

 2) Allow for 16 byte Nonce / IV (perhaps more confusing).
 ```swift
 public init(key: Array<UInt8>, iv nonce: Array<UInt8>) throws {
     precondition(nonce.count == 16 || nonce.count == 12 || nonce.count == 8)
     ...
 }
 ```

 Either method would allow for the following to be accomplished...
 Example from RFC 9001 [Appendix A.5 Quic v1](https://datatracker.ietf.org/doc/html/rfc9001#name-chacha20-poly1305-short-hea)

 ``` swift
 let hpKey = Array(hex: "0x25a282b9e82f06f21f488917a4fc8f1b73573685608597d0efcb076b0ab7a7a4")

 ///            |  Counter |           IV             |
 /// Sample: 0x | 5e5cd55c | 41f69080575d7999c25a5bfb |
 let counter = Array(hex: "0x5e5cd55c")
 let iv = Array(hex: "0x41f69080575d7999c25a5bfb")

 let mask = try CryptoSwift.ChaCha20(key: hpKey, counter: counter, iv: iv).encrypt(Array<UInt8>(repeating: 0, count: 5))

 XCTAssertEqual(mask, "aefefe7d03")
 ```

Let me know what you think

Thanks