### PR TITLE
Fix warnings with Swift 5.8

### DIFF
--- a/Sources/CryptoSwift/Scrypt.swift
+++ b/Sources/CryptoSwift/Scrypt.swift
@@ -121,7 +121,11 @@ private extension Scrypt {
 
     /* 1: X <-- B */
     let typedBlock = block.assumingMemoryBound(to: UInt32.self)
+#if compiler(>=5.8)
+    X.update(from: typedBlock, count: 32 * self.r)
+#else
     X.assign(from: typedBlock, count: 32 * self.r)
+#endif
 
     /* 2: for i = 0 to N - 1 do */
     for i in stride(from: 0, to: self.N, by: 2) {

--- a/Sources/CryptoSwift/String+Extension.swift
+++ b/Sources/CryptoSwift/String+Extension.swift
@@ -13,6 +13,8 @@
 //  - This notice may not be removed or altered from any source or binary distribution.
 //
 
+import Foundation
+
 /** String extension */
 extension String {
 


### PR DESCRIPTION
There are a few warnings when compiling `main` with Swift 5.8:

```
Sources/CryptoSwift/Scrypt.swift:124:7 'assign(from:count:)' is deprecated: renamed to 'update(from:count:)'
Sources/CryptoSwift/String+Extension.swift:21:5 Instance method 'data(using:allowLossyConversion:)' cannot be used in an '@inlinable' function because 'Foundation' was not imported by this file; this is an error in Swift 6
Sources/CryptoSwift/String+Extension.swift:21:24 Struct 'Encoding' cannot be used in an '@inlinable' function because 'Foundation' was not imported by this file; this is an error in Swift 6
Sources/CryptoSwift/String+Extension.swift:21:33 Static property 'utf8' cannot be used in an '@inlinable' function because 'Foundation' was not imported by this file; this is an error in Swift 6
```

This fixes them all while continuing to support previous Swift compiler versions.


Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- Fix warnings with Swift 5.8