### PR TITLE
PKCS7Padding: Remove unreachable if branch

### DIFF
--- a/Sources/CryptoSwift/PKCS/PKCS7Padding.swift
+++ b/Sources/CryptoSwift/PKCS/PKCS7Padding.swift
@@ -29,13 +29,8 @@ struct PKCS7Padding: PaddingProtocol {
   func add(to bytes: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
     let padding = UInt8(blockSize - (bytes.count % blockSize))
     var withPadding = bytes
-    if padding == 0 {
-      // If the original data is a multiple of N bytes, then an extra block of bytes with value N is added.
-      withPadding += Array<UInt8>(repeating: UInt8(blockSize), count: Int(blockSize))
-    } else {
-      // The value of each added byte is the number of bytes that are added
-      withPadding += Array<UInt8>(repeating: padding, count: Int(padding))
-    }
+    // The value of each added byte is the number of bytes that are added
+    withPadding += Array<UInt8>(repeating: padding, count: Int(padding))
     return withPadding
   }
 

--- a/Sources/CryptoSwift/PKCS/PKCS7Padding.swift
+++ b/Sources/CryptoSwift/PKCS/PKCS7Padding.swift
@@ -28,10 +28,8 @@ struct PKCS7Padding: PaddingProtocol {
   @inlinable
   func add(to bytes: Array<UInt8>, blockSize: Int) -> Array<UInt8> {
     let padding = UInt8(blockSize - (bytes.count % blockSize))
-    var withPadding = bytes
     // The value of each added byte is the number of bytes that are added
-    withPadding += Array<UInt8>(repeating: padding, count: Int(padding))
-    return withPadding
+    return bytes + Array<UInt8>(repeating: padding, count: Int(padding))
   }
 
   @inlinable


### PR DESCRIPTION
**Changes proposed in this pull request:**
`padding` could never be zero as `blockSize > 0` and `bytes.count % blockSize < blockSize`.
Hence, we remove the unreachable if branch.
Addresses https://github.com/krzyzanowskim/CryptoSwift/discussions/1020.

**Checklist:**
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

**Note:**
- No tests were added because change only removes unreachable code.
- `swiftformat` was run on the file that contains changes. However, running `swiftformat` on the entire repository would create a lot of additional changes, as many files don't seem to be formatted.
