### PR TITLE
Update BlockDecryptor.swift

### DIFF
--- a/Sources/CryptoSwift/BlockDecryptor.swift
+++ b/Sources/CryptoSwift/BlockDecryptor.swift
@@ -87,7 +87,7 @@ public class BlockDecryptor: Cryptor, Updatable {
 
   public func seek(to position: Int) throws {
     guard var worker = self.worker as? SeekableModeWorker else {
-      fatalError("Not supported")
+      print("Not supported")
     }
 
     try worker.seek(to: position)


### PR DESCRIPTION
fatalError("Not supported") causes crash issue for this case. It would be better if we just print something or handle any other way

Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
-
