### PR TITLE
Fixed the PrivacyInfo.xcprivacy is not copied when installed from CocoaPods or Carthage

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "11.0"
   s.source_files  = "Sources/CryptoSwift/**/*.swift"
   s.requires_arc = true
+  s.resource_bundles = {"CryptoSwift" => ["Sources/CryptoSwift/PrivacyInfo.xcprivacy"]}
 end

--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		81F279DF2181F5A000449EDA /* ScryptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F279DE2181F5A000449EDA /* ScryptTests.swift */; };
 		81F279E12181F5C500449EDA /* ScryptTestsPerf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F279E02181F5C500449EDA /* ScryptTestsPerf.swift */; };
 		81F279E22181F5C500449EDA /* ScryptTestsPerf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F279E02181F5C500449EDA /* ScryptTestsPerf.swift */; platformFilter = ios; };
+		AA54CF312B860926006BF411 /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = 75C454012B4B6EBC00FC5020 /* PrivacyInfo.xcprivacy */; };
 		E3FD2D531D6B81CE00A9F35F /* Error+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3FD2D511D6B813C00A9F35F /* Error+Extension.swift */; };
 		E6200E141FB9A7AE00258382 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6200E131FB9A7AE00258382 /* HKDF.swift */; };
 		E6200E171FB9B68C00258382 /* HKDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6200E151FB9B67C00258382 /* HKDFTests.swift */; };
@@ -225,8 +226,9 @@
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolderSpec = 7;
 			files = (
+				AA54CF312B860926006BF411 /* PrivacyInfo.xcprivacy in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests passed.

Changes proposed in this pull request:
-

Sorry. I can only use simple English. I use machine translation.

I read [this discussion](https://github.com/krzyzanowskim/CryptoSwift/discussions/1039). There seems to be a problem when installing CryptoSwift from CocoaPods or Carthage where the PrivacyInfo.xcprivacy is not copied.

This Pull Request fixed the following bugs.
* PrivacyInfo.xcprivacy was not added when installed from CocoaPods.
* PrivacyInfo.xcprivacy was not added when installed from Carthage.



Original Text: 
私は[この議論](https://github.com/krzyzanowskim/CryptoSwift/discussions/1039)を読んで検証をおこないました。
CocoaPods、またはCarthageからCryptoSwiftをインストールすると、PrivacyInfo.xcprivacy がxcframeworkへコピーされない問題があるようです。

このプルリクエストでは、以下の問題を解決しました。
* CocoaPodsからインストールした場合、CryptoSwift.xcframework に PrivacyInfo.xcprivacy が追加されていなかった問題
* Carthageからインストールした場合、CryptoSwift.xcframework に PrivacyInfo.xcprivacy が追加されていなかった問題