### PR TITLE
Fix for Privacy manifest in podspec

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "11.0"
   s.source_files  = "Sources/CryptoSwift/**/*.swift"
   s.requires_arc = true
-  s.resource_bundles = {"CryptoSwift" => ["Sources/CryptoSwift/PrivacyInfo.xcprivacy"]}
+  s.resource_bundles = {'CryptoSwift' => ['Sources/CryptoSwift/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:

Hello!
I've seen the merged https://github.com/krzyzanowskim/CryptoSwift/pull/1040, but after that there is still a problem. The pod files don't contain PrivacyManifest file. So this PR contains a little fix for it.
I checked this fix in my own project using my branch from forked repository as source for pod. It works with this fix.
<img width="360" alt="image" src="https://github.com/krzyzanowskim/CryptoSwift/assets/32792413/46298f1d-a76d-4028-bb47-ff3356d2b049">

Could you please review it?


