### PR TITLE
Remove whitespaces from file names

### DIFF
--- a/CryptoSwift.xcodeproj/project.pbxproj
+++ b/CryptoSwift.xcodeproj/project.pbxproj
@@ -18,25 +18,17 @@
 		674A736F1BF5D85B00866C5B /* RabbitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674A736E1BF5D85B00866C5B /* RabbitTests.swift */; };
 		6A7CDEED26CD1E4C00FFB1AF /* RSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7CDEEC26CD1E4C00FFB1AF /* RSATests.swift */; };
 		6AC893F626DB950F00F7E787 /* Addition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E026DB950C00F7E787 /* Addition.swift */; };
-		6AC893F726DB950F00F7E787 /* Square Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E126DB950C00F7E787 /* Square Root.swift */; };
 		6AC893F826DB950F00F7E787 /* GCD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E226DB950D00F7E787 /* GCD.swift */; };
 		6AC893F926DB950F00F7E787 /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E326DB950D00F7E787 /* Comparable.swift */; };
 		6AC893FA26DB950F00F7E787 /* Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E426DB950D00F7E787 /* Hashable.swift */; };
-		6AC893FB26DB950F00F7E787 /* Bitwise Ops.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E526DB950D00F7E787 /* Bitwise Ops.swift */; };
 		6AC893FC26DB950F00F7E787 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E626DB950D00F7E787 /* Codable.swift */; };
 		6AC893FD26DB950F00F7E787 /* Shifts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E726DB950D00F7E787 /* Shifts.swift */; };
-		6AC893FE26DB950F00F7E787 /* Prime Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E826DB950D00F7E787 /* Prime Test.swift */; };
-		6AC893FF26DB950F00F7E787 /* Words and Bits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893E926DB950D00F7E787 /* Words and Bits.swift */; };
 		6AC8940026DB950F00F7E787 /* Subtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893EA26DB950D00F7E787 /* Subtraction.swift */; };
-		6AC8940126DB950F00F7E787 /* Data Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893EB26DB950D00F7E787 /* Data Conversion.swift */; };
 		6AC8940226DB950F00F7E787 /* Multiplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893EC26DB950D00F7E787 /* Multiplication.swift */; };
-		6AC8940326DB950F00F7E787 /* Integer Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893ED26DB950E00F7E787 /* Integer Conversion.swift */; };
-		6AC8940426DB950F00F7E787 /* Floating Point Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893EE26DB950E00F7E787 /* Floating Point Conversion.swift */; };
 		6AC8940526DB950F00F7E787 /* Strideable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893EF26DB950E00F7E787 /* Strideable.swift */; };
 		6AC8940626DB950F00F7E787 /* BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F026DB950E00F7E787 /* BigInt.swift */; };
 		6AC8940726DB950F00F7E787 /* Exponentiation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F126DB950E00F7E787 /* Exponentiation.swift */; };
 		6AC8940826DB950F00F7E787 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F226DB950E00F7E787 /* Random.swift */; };
-		6AC8940926DB950F00F7E787 /* String Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F326DB950E00F7E787 /* String Conversion.swift */; };
 		6AC8940A26DB950F00F7E787 /* BigUInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F426DB950E00F7E787 /* BigUInt.swift */; };
 		6AC8940B26DB950F00F7E787 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC893F526DB950E00F7E787 /* Division.swift */; };
 		750509991F6BEF2A00394A1B /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750509981F6BEF2A00394A1B /* PKCS7.swift */; };
@@ -160,6 +152,14 @@
 		E3FD2D531D6B81CE00A9F35F /* Error+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3FD2D511D6B813C00A9F35F /* Error+Extension.swift */; };
 		E6200E141FB9A7AE00258382 /* HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6200E131FB9A7AE00258382 /* HKDF.swift */; };
 		E6200E171FB9B68C00258382 /* HKDFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6200E151FB9B67C00258382 /* HKDFTests.swift */; };
+		EC353DB42BECCEFD0026B46B /* BitwiseOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DB32BECCEFD0026B46B /* BitwiseOps.swift */; };
+		EC353DB62BECCF3A0026B46B /* DataConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DB52BECCF3A0026B46B /* DataConversion.swift */; };
+		EC353DB82BECCF4B0026B46B /* FloatingPointConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DB72BECCF4B0026B46B /* FloatingPointConversion.swift */; };
+		EC353DBA2BECCF5A0026B46B /* IntegerConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DB92BECCF5A0026B46B /* IntegerConversion.swift */; };
+		EC353DBC2BECCF6A0026B46B /* PrimeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DBB2BECCF6A0026B46B /* PrimeTest.swift */; };
+		EC353DBE2BECCF770026B46B /* SquareRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DBD2BECCF770026B46B /* SquareRoot.swift */; };
+		EC353DC02BECCF860026B46B /* StringConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DBF2BECCF860026B46B /* StringConversion.swift */; };
+		EC353DC22BECCF8F0026B46B /* WordsAndBits.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC353DC12BECCF8F0026B46B /* WordsAndBits.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -244,25 +244,17 @@
 		674A736E1BF5D85B00866C5B /* RabbitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RabbitTests.swift; sourceTree = "<group>"; };
 		6A7CDEEC26CD1E4C00FFB1AF /* RSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSATests.swift; sourceTree = "<group>"; };
 		6AC893E026DB950C00F7E787 /* Addition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Addition.swift; sourceTree = "<group>"; };
-		6AC893E126DB950C00F7E787 /* Square Root.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Square Root.swift"; sourceTree = "<group>"; };
 		6AC893E226DB950D00F7E787 /* GCD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCD.swift; sourceTree = "<group>"; };
 		6AC893E326DB950D00F7E787 /* Comparable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		6AC893E426DB950D00F7E787 /* Hashable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hashable.swift; sourceTree = "<group>"; };
-		6AC893E526DB950D00F7E787 /* Bitwise Ops.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bitwise Ops.swift"; sourceTree = "<group>"; };
 		6AC893E626DB950D00F7E787 /* Codable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
 		6AC893E726DB950D00F7E787 /* Shifts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shifts.swift; sourceTree = "<group>"; };
-		6AC893E826DB950D00F7E787 /* Prime Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Prime Test.swift"; sourceTree = "<group>"; };
-		6AC893E926DB950D00F7E787 /* Words and Bits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Words and Bits.swift"; sourceTree = "<group>"; };
 		6AC893EA26DB950D00F7E787 /* Subtraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subtraction.swift; sourceTree = "<group>"; };
-		6AC893EB26DB950D00F7E787 /* Data Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data Conversion.swift"; sourceTree = "<group>"; };
 		6AC893EC26DB950D00F7E787 /* Multiplication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Multiplication.swift; sourceTree = "<group>"; };
-		6AC893ED26DB950E00F7E787 /* Integer Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Integer Conversion.swift"; sourceTree = "<group>"; };
-		6AC893EE26DB950E00F7E787 /* Floating Point Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Floating Point Conversion.swift"; sourceTree = "<group>"; };
 		6AC893EF26DB950E00F7E787 /* Strideable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strideable.swift; sourceTree = "<group>"; };
 		6AC893F026DB950E00F7E787 /* BigInt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BigInt.swift; sourceTree = "<group>"; };
 		6AC893F126DB950E00F7E787 /* Exponentiation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Exponentiation.swift; sourceTree = "<group>"; };
 		6AC893F226DB950E00F7E787 /* Random.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
-		6AC893F326DB950E00F7E787 /* String Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String Conversion.swift"; sourceTree = "<group>"; };
 		6AC893F426DB950E00F7E787 /* BigUInt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BigUInt.swift; sourceTree = "<group>"; };
 		6AC893F526DB950E00F7E787 /* Division.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Division.swift; sourceTree = "<group>"; };
 		750509981F6BEF2A00394A1B /* PKCS7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCS7.swift; sourceTree = "<group>"; };
@@ -394,6 +386,14 @@
 		E3FD2D511D6B813C00A9F35F /* Error+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Error+Extension.swift"; sourceTree = "<group>"; };
 		E6200E131FB9A7AE00258382 /* HKDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKDF.swift; sourceTree = "<group>"; };
 		E6200E151FB9B67C00258382 /* HKDFTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HKDFTests.swift; sourceTree = "<group>"; };
+		EC353DB32BECCEFD0026B46B /* BitwiseOps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BitwiseOps.swift; sourceTree = "<group>"; };
+		EC353DB52BECCF3A0026B46B /* DataConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataConversion.swift; sourceTree = "<group>"; };
+		EC353DB72BECCF4B0026B46B /* FloatingPointConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPointConversion.swift; sourceTree = "<group>"; };
+		EC353DB92BECCF5A0026B46B /* IntegerConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegerConversion.swift; sourceTree = "<group>"; };
+		EC353DBB2BECCF6A0026B46B /* PrimeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimeTest.swift; sourceTree = "<group>"; };
+		EC353DBD2BECCF770026B46B /* SquareRoot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SquareRoot.swift; sourceTree = "<group>"; };
+		EC353DBF2BECCF860026B46B /* StringConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringConversion.swift; sourceTree = "<group>"; };
+		EC353DC12BECCF8F0026B46B /* WordsAndBits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordsAndBits.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -453,25 +453,25 @@
 				6AC893E026DB950C00F7E787 /* Addition.swift */,
 				6AC893F026DB950E00F7E787 /* BigInt.swift */,
 				6AC893F426DB950E00F7E787 /* BigUInt.swift */,
-				6AC893E526DB950D00F7E787 /* Bitwise Ops.swift */,
+				EC353DB32BECCEFD0026B46B /* BitwiseOps.swift */,
 				6AC893E626DB950D00F7E787 /* Codable.swift */,
 				6AC893E326DB950D00F7E787 /* Comparable.swift */,
-				6AC893EB26DB950D00F7E787 /* Data Conversion.swift */,
+				EC353DB52BECCF3A0026B46B /* DataConversion.swift */,
 				6AC893F526DB950E00F7E787 /* Division.swift */,
 				6AC893F126DB950E00F7E787 /* Exponentiation.swift */,
-				6AC893EE26DB950E00F7E787 /* Floating Point Conversion.swift */,
+				EC353DB72BECCF4B0026B46B /* FloatingPointConversion.swift */,
 				6AC893E226DB950D00F7E787 /* GCD.swift */,
 				6AC893E426DB950D00F7E787 /* Hashable.swift */,
-				6AC893ED26DB950E00F7E787 /* Integer Conversion.swift */,
+				EC353DB92BECCF5A0026B46B /* IntegerConversion.swift */,
 				6AC893EC26DB950D00F7E787 /* Multiplication.swift */,
-				6AC893E826DB950D00F7E787 /* Prime Test.swift */,
+				EC353DBB2BECCF6A0026B46B /* PrimeTest.swift */,
 				6AC893F226DB950E00F7E787 /* Random.swift */,
 				6AC893E726DB950D00F7E787 /* Shifts.swift */,
-				6AC893E126DB950C00F7E787 /* Square Root.swift */,
+				EC353DBD2BECCF770026B46B /* SquareRoot.swift */,
 				6AC893EF26DB950E00F7E787 /* Strideable.swift */,
-				6AC893F326DB950E00F7E787 /* String Conversion.swift */,
+				EC353DBF2BECCF860026B46B /* StringConversion.swift */,
 				6AC893EA26DB950D00F7E787 /* Subtraction.swift */,
-				6AC893E926DB950D00F7E787 /* Words and Bits.swift */,
+				EC353DC12BECCF8F0026B46B /* WordsAndBits.swift */,
 				7571938D2816BFE3001C3AC0 /* CS.swift */,
 			);
 			path = CS_BigInt;
@@ -963,13 +963,16 @@
 			files = (
 				7507705F28D61E78004A44DC /* RSA.swift in Sources */,
 				42012783267A6F1C00F82506 /* ISO10126Padding.swift in Sources */,
-				6AC8940926DB950F00F7E787 /* String Conversion.swift in Sources */,
+				EC353DB42BECCEFD0026B46B /* BitwiseOps.swift in Sources */,
 				6AC8940226DB950F00F7E787 /* Multiplication.swift in Sources */,
 				0AF023D5230F2B0F008E4E68 /* ISO78164Padding.swift in Sources */,
+				EC353DBA2BECCF5A0026B46B /* IntegerConversion.swift in Sources */,
 				75EC52861EE8B8170048EB3B /* CFB.swift in Sources */,
-				6AC893FF26DB950F00F7E787 /* Words and Bits.swift in Sources */,
 				75EC52901EE8B81A0048EB3B /* Collection+Extension.swift in Sources */,
+				EC353DBE2BECCF770026B46B /* SquareRoot.swift in Sources */,
+				EC353DC02BECCF860026B46B /* StringConversion.swift in Sources */,
 				0EE73E71204D598100110E11 /* CMAC.swift in Sources */,
+				EC353DBC2BECCF6A0026B46B /* PrimeTest.swift in Sources */,
 				7523742D2083C61D0016D662 /* GCM.swift in Sources */,
 				75F4E436216C98DE00F09710 /* CBCMAC.swift in Sources */,
 				752BED9F208C135700FC4743 /* AES+Foundation.swift in Sources */,
@@ -985,7 +988,6 @@
 				75EC52821EE8B8170048EB3B /* BlockMode.swift in Sources */,
 				75EC52AE1EE8B83D0048EB3B /* SecureBytes.swift in Sources */,
 				6AC893FC26DB950F00F7E787 /* Codable.swift in Sources */,
-				6AC8940126DB950F00F7E787 /* Data Conversion.swift in Sources */,
 				75EC528F1EE8B81A0048EB3B /* Cipher.swift in Sources */,
 				75B3ED79210FA016005D4ADA /* BlockEncryptor.swift in Sources */,
 				75EC52A01EE8B8290048EB3B /* Int+Extension.swift in Sources */,
@@ -1005,11 +1007,9 @@
 				6AC8940726DB950F00F7E787 /* Exponentiation.swift in Sources */,
 				6AC8940026DB950F00F7E787 /* Subtraction.swift in Sources */,
 				75EC52A61EE8B8390048EB3B /* PBKDF1.swift in Sources */,
-				6AC893FB26DB950F00F7E787 /* Bitwise Ops.swift in Sources */,
 				75EC52B41EE8B83D0048EB3B /* UInt32+Extension.swift in Sources */,
 				6AC8940526DB950F00F7E787 /* Strideable.swift in Sources */,
 				75EC52911EE8B81A0048EB3B /* Cryptors.swift in Sources */,
-				6AC893F726DB950F00F7E787 /* Square Root.swift in Sources */,
 				75EC52881EE8B8170048EB3B /* ECB.swift in Sources */,
 				75EC52841EE8B8170048EB3B /* CipherModeWorker.swift in Sources */,
 				75EC52A41EE8B8290048EB3B /* Operators.swift in Sources */,
@@ -1019,11 +1019,11 @@
 				750509991F6BEF2A00394A1B /* PKCS7.swift in Sources */,
 				7507706C28D61E97004A44DC /* ASN1Decoder.swift in Sources */,
 				75EC52B51EE8B83D0048EB3B /* UInt64+Extension.swift in Sources */,
+				EC353DB62BECCF3A0026B46B /* DataConversion.swift in Sources */,
 				7507707128D61ED5004A44DC /* Signature.swift in Sources */,
 				75EC52AF1EE8B83D0048EB3B /* SHA1.swift in Sources */,
 				75EC52801EE8B8130048EB3B /* Bit.swift in Sources */,
 				7507706D28D61E97004A44DC /* ASN1.swift in Sources */,
-				6AC8940326DB950F00F7E787 /* Integer Conversion.swift in Sources */,
 				75EC52971EE8B8200048EB3B /* ChaCha20+Foundation.swift in Sources */,
 				75F4E434216C93EF00F09710 /* CCM.swift in Sources */,
 				75EC52871EE8B8170048EB3B /* CTR.swift in Sources */,
@@ -1037,12 +1037,12 @@
 				6AC8940A26DB950F00F7E787 /* BigUInt.swift in Sources */,
 				75EC527F1EE8B8130048EB3B /* BatchedCollection.swift in Sources */,
 				75EC52991EE8B8200048EB3B /* Data+Extension.swift in Sources */,
-				6AC8940426DB950F00F7E787 /* Floating Point Conversion.swift in Sources */,
 				75EC52B61EE8B83D0048EB3B /* UInt8+Extension.swift in Sources */,
 				75EC52891EE8B8170048EB3B /* OFB.swift in Sources */,
 				75EC52831EE8B8170048EB3B /* BlockModeOptions.swift in Sources */,
 				753674072175D012003E32A6 /* StreamDecryptor.swift in Sources */,
 				6AC8940626DB950F00F7E787 /* BigInt.swift in Sources */,
+				EC353DC22BECCF8F0026B46B /* WordsAndBits.swift in Sources */,
 				751EE9781F93996100161FFC /* AES.Cryptors.swift in Sources */,
 				75EC527D1EE8B8130048EB3B /* Array+Extension.swift in Sources */,
 				75D7AF38208BFB1600D22BEB /* UInt128.swift in Sources */,
@@ -1057,7 +1057,6 @@
 				75EC52851EE8B8170048EB3B /* CBC.swift in Sources */,
 				75EC52A71EE8B8390048EB3B /* PBKDF2.swift in Sources */,
 				75EC529D1EE8B8200048EB3B /* Utils+Foundation.swift in Sources */,
-				6AC893FE26DB950F00F7E787 /* Prime Test.swift in Sources */,
 				75EC527E1EE8B8130048EB3B /* Authenticator.swift in Sources */,
 				7507706A28D61E97004A44DC /* ASN1Scanner.swift in Sources */,
 				75EC52AB1EE8B83D0048EB3B /* Rabbit.swift in Sources */,
@@ -1068,6 +1067,7 @@
 				75EC52981EE8B8200048EB3B /* Array+Foundation.swift in Sources */,
 				75EC52B11EE8B83D0048EB3B /* SHA3.swift in Sources */,
 				75EC52A31EE8B8290048EB3B /* NoPadding.swift in Sources */,
+				EC353DB82BECCF4B0026B46B /* FloatingPointConversion.swift in Sources */,
 				6AC893F826DB950F00F7E787 /* GCD.swift in Sources */,
 				81F279DD2181F58300449EDA /* Scrypt.swift in Sources */,
 				75EC52931EE8B81A0048EB3B /* Digest.swift in Sources */,

--- a/Sources/CryptoSwift/CS_BigInt/BitwiseOps.swift
+++ b/Sources/CryptoSwift/CS_BigInt/BitwiseOps.swift
@@ -1,5 +1,5 @@
 //
-//  Bitwise Ops.swift
+//  BitwiseOps.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2016-01-03.

--- a/Sources/CryptoSwift/CS_BigInt/DataConversion.swift
+++ b/Sources/CryptoSwift/CS_BigInt/DataConversion.swift
@@ -1,5 +1,5 @@
 //
-//  Data Conversion.swift
+//  DataConversion.swift
 //  BigInt
 //
 //  Created by Károly Lőrentey on 2016-01-04.

--- a/Sources/CryptoSwift/CS_BigInt/FloatingPointConversion.swift
+++ b/Sources/CryptoSwift/CS_BigInt/FloatingPointConversion.swift
@@ -1,5 +1,5 @@
 //
-//  Floating Point Conversion.swift
+//  FloatingPointConversion.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2017-08-11.

--- a/Sources/CryptoSwift/CS_BigInt/IntegerConversion.swift
+++ b/Sources/CryptoSwift/CS_BigInt/IntegerConversion.swift
@@ -1,5 +1,5 @@
 //
-//  Integer Conversion.swift
+//  IntegerConversion.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2017-08-11.

--- a/Sources/CryptoSwift/CS_BigInt/PrimeTest.swift
+++ b/Sources/CryptoSwift/CS_BigInt/PrimeTest.swift
@@ -1,5 +1,5 @@
 //
-//  Prime Test.swift
+//  PrimeTest.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2016-01-04.

--- a/Sources/CryptoSwift/CS_BigInt/SquareRoot.swift
+++ b/Sources/CryptoSwift/CS_BigInt/SquareRoot.swift
@@ -1,5 +1,5 @@
 //
-//  Square Root.swift
+//  SquareRoot.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2016-01-03.

--- a/Sources/CryptoSwift/CS_BigInt/StringConversion.swift
+++ b/Sources/CryptoSwift/CS_BigInt/StringConversion.swift
@@ -1,5 +1,5 @@
 //
-//  String Conversion.swift
+//  StringConversion.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2016-01-03.

--- a/Sources/CryptoSwift/CS_BigInt/WordsAndBits.swift
+++ b/Sources/CryptoSwift/CS_BigInt/WordsAndBits.swift
@@ -1,5 +1,5 @@
 //
-//  Words and Bits.swift
+//  WordsAndBits.swift
 //  CS.BigInt
 //
 //  Created by Károly Lőrentey on 2017-08-11.


### PR DESCRIPTION
Helps remedy issue with bazel coverage command https://github.com/bazelbuild/bazel/issues/4327

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- Renamed a couple of files such that they no longer contain whitespaces.
- Whitespaces present an issue when using this library with Bazel build system.
- This is a minor change for the CryptoSwift but solves many problems for developers on Apple platforms who are using Bazel.