### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,6 @@ let package = Package(
 #if swift(>=5.6)
   // Add the documentation compiler plugin if possible
   package.dependencies.append(
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0")
   )
 #endif

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Platform](https://img.shields.io/badge/Platforms-iOS%20%7C%20Android%20%7CmacOS%20%7C%20watchOS%20%7C%20tvOS%20%7C%20Linux-4E4E4E.svg?colorA=28a745)](#installation)
 
 [![Swift support](https://img.shields.io/badge/Swift-3.1%20%7C%203.2%20%7C%204.0%20%7C%204.1%20%7C%204.2%20%7C%205.0-lightgrey.svg?colorA=28a745&colorB=4E4E4E)](#swift-versions-support)
-[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg?style=flat&colorA=28a745&&colorB=4E4E4E)](https://github.com/apple/swift-package-manager)
+[![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg?style=flat&colorA=28a745&&colorB=4E4E4E)](https://github.com/swiftlang/swift-package-manager)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/CryptoSwift.svg?style=flat&label=CocoaPods&colorA=28a745&&colorB=4E4E4E)](https://cocoapods.org/pods/CryptoSwift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-brightgreen.svg?style=flat&colorA=28a745&&colorB=4E4E4E)](https://github.com/Carthage/Carthage)
 


### PR DESCRIPTION
### Summary:

Update links for repositories moved to the swiftlang org on GitHub

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:

Correct the reference
+ https://github.com/apple/swift-docc-plugin => https://github.com/swiftlang/swift-docc-plugin
+ https://github.com/apple/swift-package-manager  =>  https://github.com/swiftlang/swift-package-manager
