### PR TITLE
Support for Static Linux SDK Based on Musl Instead of Glibc

### DIFF
--- a/Sources/CryptoSwift/BlockMode/CCM.swift
+++ b/Sources/CryptoSwift/BlockMode/CCM.swift
@@ -21,6 +21,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #elseif canImport(WASILibc)

--- a/Sources/CryptoSwift/Cryptors.swift
+++ b/Sources/CryptoSwift/Cryptors.swift
@@ -17,6 +17,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif

--- a/Sources/CryptoSwift/HKDF.swift
+++ b/Sources/CryptoSwift/HKDF.swift
@@ -20,6 +20,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #elseif canImport(WASILibc)

--- a/Sources/CryptoSwift/Int+Extension.swift
+++ b/Sources/CryptoSwift/Int+Extension.swift
@@ -18,6 +18,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif

--- a/Sources/CryptoSwift/PKCS/PBKDF2.swift
+++ b/Sources/CryptoSwift/PKCS/PBKDF2.swift
@@ -20,6 +20,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #elseif canImport(WASILibc)

--- a/Sources/CryptoSwift/SHA3.swift
+++ b/Sources/CryptoSwift/SHA3.swift
@@ -21,6 +21,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif

--- a/Sources/CryptoSwift/SecureBytes.swift
+++ b/Sources/CryptoSwift/SecureBytes.swift
@@ -17,6 +17,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WinSDK)
 import WinSDK
 #endif

--- a/Sources/CryptoSwift/UInt32+Extension.swift
+++ b/Sources/CryptoSwift/UInt32+Extension.swift
@@ -17,6 +17,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif

--- a/Sources/CryptoSwift/UInt8+Extension.swift
+++ b/Sources/CryptoSwift/UInt8+Extension.swift
@@ -17,6 +17,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(ucrt)
 import ucrt
 #endif


### PR DESCRIPTION
Hello,

I am currently working on a project that requires the use of a static Linux SDK. We are opting to use Musl instead of Glibc due to its excellent support for static linking and its permissive licensing, which simplifies the distribution of statically linked executables.

To ensure compatibility with Musl, I suggest a modification in the conditional compilation statements for importing C libraries. Here is the current code:

#if canImport(Darwin)
import Darwin
#elseif canImport(Glibc)
import Glibc
#elseif canImport(WinSDK)
import WinSDK
#endif

And here is the proposed change:

#if canImport(Darwin)
import Darwin
#elseif canImport(Glibc)
import Glibc
#elseif canImport(Musl)
import Musl
#elseif canImport(WinSDK)
import WinSDK
#endif

This change will allow the framework to dynamically check for the availability of Glibc or Musl, thus supporting environments built with Musl. This would greatly enhance the flexibility and usability of SwifterSwift in various Linux environments.

For further reference on static linking in Linux, you can visit the official Swift documentation: 
[Static Linux Getting Started](https://www.swift.org/documentation/articles/static-linux-getting-started.html).

Thank you for considering this enhancement.