### PR TITLE
fix: externalRepresentation condition to validate if key is private should be d not prime

### DIFF
--- a/Sources/CryptoSwift/RSA/RSA.swift
+++ b/Sources/CryptoSwift/RSA/RSA.swift
@@ -61,7 +61,7 @@ public final class RSA: DERCodable {
   public let keySizeBytes: Int
 
   /// The underlying primes used to generate the Private Exponent
-  private let primes: (p: BigUInteger, q: BigUInteger)?
+  public let primes: (p: BigUInteger, q: BigUInteger)?
 
   /// Initialize with RSA parameters
   /// - Parameters:
@@ -388,7 +388,7 @@ extension RSA {
   /// ```
   ///
   public func externalRepresentation() throws -> Data {
-    if self.primes != nil {
+    if self.d != nil {
       return try Data(self.privateKeyDER())
     } else {
       return try Data(self.publicKeyDER())


### PR DESCRIPTION
Fixes #

I got to this issue recently where the library was giving me a public key DER when the key had a d and no primes, this is misleading since an RSA key can have d and no primes. This function should acess if the key is private through the d, if it requires the primes it should return an error.

As part of this PR I also made the primes public, they are already a let, making them public makes the API more accessible to deal for example if I want to build a JWK with primes included.
It is quite difficult right now if you want to expose this keys to other coding types since the primes are private, and as far as I know there is no reason for that.

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- RSA.externalRepresentation() private of public condition should be made validate through the variable d not primes.
- Change primes to public.