### PR TITLE
Use `.sha2(.sha256)` for PBKDF2 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ try CMAC(key: key).authenticate(bytes)
 let password: Array<UInt8> = Array("s33krit".utf8)
 let salt: Array<UInt8> = Array("nacllcan".utf8)
 
-let key = try PKCS5.PBKDF2(password: password, salt: salt, iterations: 4096, keyLength: 32, variant: .sha256).calculate()
+let key = try PKCS5.PBKDF2(password: password, salt: salt, iterations: 4096, keyLength: 32, variant: .sha2(.sha256)).calculate()
 ```
 
 ```swift


### PR DESCRIPTION
.sha256 is deprecated if I'm reading this right.

Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- Replace a deprecated call in an example in the readme with a non-deprecated equivalent. 
