### PR TITLE
docs: Fix typos in comment

### DIFF
--- a/Sources/CryptoSwift/PKCS/PKCS1v15.swift
+++ b/Sources/CryptoSwift/PKCS/PKCS1v15.swift
@@ -58,7 +58,7 @@ struct EMSAPKCS1v15Padding: PaddingProtocol {
 
 /// EME PKCS1 v1.5 Padding Scheme
 ///
-/// The EME Version of the PKCS1 v1.5 padding scheme is **non deterministic** (it pads the messages contents with psuedo-random bytes)
+/// The EME Version of the PKCS1 v1.5 padding scheme is **non deterministic** (it pads the messages contents with pseudo-random bytes)
 /// ```
 /// // The returned structure
 /// // - PS is the applied padding

--- a/Tests/CryptoSwiftTests/RSATests.swift
+++ b/Tests/CryptoSwiftTests/RSATests.swift
@@ -453,7 +453,7 @@ final class RSATests: XCTestCase {
             // Signing data requires access to the private key, therefore this should throw an error when called on a public key
             XCTAssertThrowsError(try rsa.sign(message.key.bytes, variant: variant), "Signature<\(test.key)>::Did not throw error")
 
-            // Sometimes the message is too long to be safely signed by our key. When this happens we should encouter an error and our test value should be empty.
+            // Sometimes the message is too long to be safely signed by our key. When this happens we should encounter an error and our test value should be empty.
             if test.value == "" {
               XCTAssertThrowsError(try rsa.verify(signature: Data(base64Encoded: test.value)!.bytes, for: message.key.bytes, variant: variant), "Signature<\(test.key)>::Did not throw error")
             } else {


### PR DESCRIPTION
Fixes #
Fixes typos:
- `psuedo` -> `pseudo`
- `encouter` -> `encounter`

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
- This PR improves documentation accuracy and test case clarity.
