### PR TITLE
Rename the `bytes` computed property in the extension on `Data` to `byteArray`

### DIFF
--- a/Sources/CryptoSwift/ASN1/ASN1Encoder.swift
+++ b/Sources/CryptoSwift/ASN1/ASN1Encoder.swift
@@ -28,15 +28,15 @@ extension ASN1 {
     public static func encode(_ node: ASN1.Node) -> [UInt8] {
       switch node {
         case .integer(let integer):
-          return IDENTIFIERS.INTERGER.bytes + self.asn1LengthPrefixed(integer.bytes)
+          return IDENTIFIERS.INTERGER.bytes + self.asn1LengthPrefixed(integer.byteArray)
         case .bitString(let bits):
-          return IDENTIFIERS.BITSTRING.bytes + self.asn1LengthPrefixed([0x00] + bits.bytes)
+          return IDENTIFIERS.BITSTRING.bytes + self.asn1LengthPrefixed([0x00] + bits.byteArray)
         case .octetString(let octet):
-          return IDENTIFIERS.OCTETSTRING.bytes + self.asn1LengthPrefixed(octet.bytes)
+          return IDENTIFIERS.OCTETSTRING.bytes + self.asn1LengthPrefixed(octet.byteArray)
         case .null:
           return IDENTIFIERS.NULL.bytes
         case .objectIdentifier(let oid):
-          return IDENTIFIERS.OBJECTID.bytes + self.asn1LengthPrefixed(oid.bytes)
+          return IDENTIFIERS.OBJECTID.bytes + self.asn1LengthPrefixed(oid.byteArray)
         case .sequence(let nodes):
           return IDENTIFIERS.SEQUENCE.bytes + self.asn1LengthPrefixed( nodes.reduce(into: Array<UInt8>(), { partialResult, node in
             partialResult += encode(node)

--- a/Sources/CryptoSwift/Foundation/Array+Foundation.swift
+++ b/Sources/CryptoSwift/Foundation/Array+Foundation.swift
@@ -27,6 +27,6 @@ public extension Array where Element == UInt8 {
       return
     }
 
-    append(contentsOf: decodedData.bytes)
+    append(contentsOf: decodedData.byteArray)
   }
 }

--- a/Sources/CryptoSwift/Foundation/Data+Extension.swift
+++ b/Sources/CryptoSwift/Foundation/Data+Extension.swift
@@ -25,55 +25,55 @@ extension Data {
   }
 
   public func md5() -> Data {
-    Data( Digest.md5(bytes))
+    Data( Digest.md5(byteArray))
   }
 
   public func sha1() -> Data {
-    Data( Digest.sha1(bytes))
+    Data( Digest.sha1(byteArray))
   }
 
   public func sha224() -> Data {
-    Data( Digest.sha224(bytes))
+    Data( Digest.sha224(byteArray))
   }
 
   public func sha256() -> Data {
-    Data( Digest.sha256(bytes))
+    Data( Digest.sha256(byteArray))
   }
 
   public func sha384() -> Data {
-    Data( Digest.sha384(bytes))
+    Data( Digest.sha384(byteArray))
   }
 
   public func sha512() -> Data {
-    Data( Digest.sha512(bytes))
+    Data( Digest.sha512(byteArray))
   }
 
   public func sha3(_ variant: SHA3.Variant) -> Data {
-    Data( Digest.sha3(bytes, variant: variant))
+    Data( Digest.sha3(byteArray, variant: variant))
   }
 
   public func crc32(seed: UInt32? = nil, reflect: Bool = true) -> Data {
-    Data( Checksum.crc32(bytes, seed: seed, reflect: reflect).bytes())
+    Data( Checksum.crc32(byteArray, seed: seed, reflect: reflect).bytes())
   }
 
   public func crc32c(seed: UInt32? = nil, reflect: Bool = true) -> Data {
-    Data( Checksum.crc32c(bytes, seed: seed, reflect: reflect).bytes())
+    Data( Checksum.crc32c(byteArray, seed: seed, reflect: reflect).bytes())
   }
 
   public func crc16(seed: UInt16? = nil) -> Data {
-    Data( Checksum.crc16(bytes, seed: seed).bytes())
+    Data( Checksum.crc16(byteArray, seed: seed).bytes())
   }
 
   public func encrypt(cipher: Cipher) throws -> Data {
-    Data( try cipher.encrypt(bytes.slice))
+    Data( try cipher.encrypt(byteArray.slice))
   }
 
   public func decrypt(cipher: Cipher) throws -> Data {
-    Data( try cipher.decrypt(bytes.slice))
+    Data( try cipher.decrypt(byteArray.slice))
   }
 
   public func authenticate(with authenticator: Authenticator) throws -> Data {
-    Data( try authenticator.authenticate(bytes))
+    Data( try authenticator.authenticate(byteArray))
   }
 }
 
@@ -82,11 +82,11 @@ extension Data {
     self.init(Array<UInt8>(hex: hex))
   }
 
-  public var bytes: Array<UInt8> {
+  public var byteArray: Array<UInt8> {
     Array(self)
   }
 
   public func toHexString() -> String {
-    self.bytes.toHexString()
+    self.byteArray.toHexString()
   }
 }

--- a/Sources/CryptoSwift/Foundation/String+FoundationExtension.swift
+++ b/Sources/CryptoSwift/Foundation/String+FoundationExtension.swift
@@ -36,6 +36,6 @@ extension String {
       throw CipherError.decrypt
     }
 
-    return try decodedData.decrypt(cipher: cipher).bytes
+    return try decodedData.decrypt(cipher: cipher).byteArray
   }
 }

--- a/Sources/CryptoSwift/RSA/RSA+Cipher.swift
+++ b/Sources/CryptoSwift/RSA/RSA+Cipher.swift
@@ -36,7 +36,7 @@ extension RSA: Cipher {
   @inlinable
   internal func encryptPreparedBytes(_ bytes: Array<UInt8>) throws -> Array<UInt8> {
     // Calculate encrypted data
-    return BigUInteger(Data(bytes)).power(self.e, modulus: self.n).serialize().bytes
+    return BigUInteger(Data(bytes)).power(self.e, modulus: self.n).serialize().byteArray
   }
 
   @inlinable
@@ -59,7 +59,7 @@ extension RSA: Cipher {
     guard let d = d else { throw RSA.Error.noPrivateKey }
 
     // Calculate decrypted data
-    return BigUInteger(Data(bytes)).power(d, modulus: self.n).serialize().bytes
+    return BigUInteger(Data(bytes)).power(d, modulus: self.n).serialize().byteArray
   }
 }
 

--- a/Sources/CryptoSwift/RSA/RSA+Signature.swift
+++ b/Sources/CryptoSwift/RSA/RSA+Signature.swift
@@ -35,7 +35,7 @@ extension RSA: Signature {
     let hashedAndEncoded = try RSA.hashedAndEncoded(bytes, variant: variant, keySizeInBytes: self.keySizeBytes)
 
     /// Calculate the Signature
-    let signedData = BigUInteger(Data(hashedAndEncoded)).power(d, modulus: self.n).serialize().bytes
+    let signedData = BigUInteger(Data(hashedAndEncoded)).power(d, modulus: self.n).serialize().byteArray
 
     return variant.formatSignedBytes(signedData, blockSize: self.keySizeBytes)
   }
@@ -61,7 +61,7 @@ extension RSA: Signature {
     if expectedData.count == self.keySizeBytes && expectedData.prefix(1) == [0x00] { expectedData = Array(expectedData.dropFirst()) }
 
     /// Step 2: 'Decrypt' the signature
-    let signatureResult = BigUInteger(Data(signature)).power(self.e, modulus: self.n).serialize().bytes
+    let signatureResult = BigUInteger(Data(signature)).power(self.e, modulus: self.n).serialize().byteArray
 
     /// Step 3: Compare the 'decrypted' signature with the prepared / encoded expected message....
     guard signatureResult == expectedData else { return false }

--- a/Sources/CryptoSwift/RSA/RSA.swift
+++ b/Sources/CryptoSwift/RSA/RSA.swift
@@ -259,8 +259,8 @@ extension RSA {
   /// // rsaKey.verify(...)
   /// ```
   public convenience init(rawRepresentation raw: Data) throws {
-    do { try self.init(privateDER: raw.bytes) } catch {
-      try self.init(publicDER: raw.bytes)
+    do { try self.init(privateDER: raw.byteArray) } catch {
+      try self.init(publicDER: raw.byteArray)
     }
   }
 }
@@ -286,8 +286,8 @@ extension RSA {
     let exp = self.e.serialize()
     let pubKeyAsnNode: ASN1.Node =
       .sequence(nodes: [
-        .integer(data: DER.i2ospData(x: mod.bytes, size: self.keySizeBytes)),
-        .integer(data: DER.i2ospData(x: exp.bytes, size: exp.bytes.count))
+        .integer(data: DER.i2ospData(x: mod.byteArray, size: self.keySizeBytes)),
+        .integer(data: DER.i2ospData(x: exp.byteArray, size: exp.byteArray.count))
       ])
     return ASN1.Encoder.encode(pubKeyAsnNode)
   }
@@ -326,14 +326,14 @@ extension RSA {
     let privateKeyAsnNode: ASN1.Node =
       .sequence(nodes: [
         .integer(data: Data(hex: "0x00")),
-        .integer(data: DER.i2ospData(x: mod.bytes, size: self.keySizeBytes)),
-        .integer(data: DER.i2ospData(x: self.e.serialize().bytes, size: 3)),
-        .integer(data: DER.i2ospData(x: d.serialize().bytes, size: self.keySizeBytes)),
-        .integer(data: DER.i2ospData(x: primes.p.serialize().bytes, size: paramWidth)),
-        .integer(data: DER.i2ospData(x: primes.q.serialize().bytes, size: paramWidth)),
-        .integer(data: DER.i2ospData(x: (d % (primes.p - 1)).serialize().bytes, size: paramWidth)),
-        .integer(data: DER.i2ospData(x: (d % (primes.q - 1)).serialize().bytes, size: paramWidth)),
-        .integer(data: DER.i2ospData(x: coefficient.serialize().bytes, size: paramWidth))
+        .integer(data: DER.i2ospData(x: mod.byteArray, size: self.keySizeBytes)),
+        .integer(data: DER.i2ospData(x: self.e.serialize().byteArray, size: 3)),
+        .integer(data: DER.i2ospData(x: d.serialize().byteArray, size: self.keySizeBytes)),
+        .integer(data: DER.i2ospData(x: primes.p.serialize().byteArray, size: paramWidth)),
+        .integer(data: DER.i2ospData(x: primes.q.serialize().byteArray, size: paramWidth)),
+        .integer(data: DER.i2ospData(x: (d % (primes.p - 1)).serialize().byteArray, size: paramWidth)),
+        .integer(data: DER.i2ospData(x: (d % (primes.q - 1)).serialize().byteArray, size: paramWidth)),
+        .integer(data: DER.i2ospData(x: coefficient.serialize().byteArray, size: paramWidth))
       ])
 
     // Encode and return the data

--- a/Sources/CryptoSwift/String+Extension.swift
+++ b/Sources/CryptoSwift/String+Extension.swift
@@ -20,7 +20,7 @@ extension String {
 
   @inlinable
   public var bytes: Array<UInt8> {
-    data(using: String.Encoding.utf8, allowLossyConversion: true)?.bytes ?? Array(utf8)
+    data(using: String.Encoding.utf8, allowLossyConversion: true)?.byteArray ?? Array(utf8)
   }
 
   @inlinable

--- a/Sources/CryptoSwift/UInt128.swift
+++ b/Sources/CryptoSwift/UInt128.swift
@@ -58,7 +58,7 @@ struct UInt128: Equatable, ExpressibleByIntegerLiteral {
     var result = Data()
     result.append(ar)
     result.append(br)
-    return result.bytes
+    return result.byteArray
   }
 
   static func ^ (n1: UInt128, n2: UInt128) -> UInt128 {

--- a/Tests/CryptoSwiftTests/Access.swift
+++ b/Tests/CryptoSwiftTests/Access.swift
@@ -142,7 +142,7 @@ class Access: XCTestCase {
     _ = data.crc32()
     _ = data.crc32c()
 
-    _ = data.bytes
+    _ = data.byteArray
     _ = data.toHexString()
 
     do {

--- a/Tests/CryptoSwiftTests/DigestTests.swift
+++ b/Tests/CryptoSwiftTests/DigestTests.swift
@@ -242,31 +242,31 @@ final class DigestTests: XCTestCase {
       let input = Data(bytes: buf, count: testSize)
 
       // SHA1
-      let sha1Once = SHA1().calculate(for: input.bytes)
+      let sha1Once = SHA1().calculate(for: input.byteArray)
 
       var sha1Partial = SHA1()
       for batch in input.batched(by: 17) {
-        _ = try sha1Partial.update(withBytes: batch.bytes)
+        _ = try sha1Partial.update(withBytes: batch.byteArray)
       }
       let sha1Result = try sha1Partial.finish()
       XCTAssertEqual(sha1Once, sha1Result)
 
       // SHA2
-      let sha2Once = SHA2(variant: .sha224).calculate(for: input.bytes)
+      let sha2Once = SHA2(variant: .sha224).calculate(for: input.byteArray)
 
       var sha2Partial = SHA2(variant: .sha224)
       for batch in input.batched(by: 17) {
-        _ = try sha2Partial.update(withBytes: batch.bytes)
+        _ = try sha2Partial.update(withBytes: batch.byteArray)
       }
       let sha2Result = try sha2Partial.finish()
       XCTAssertEqual(sha2Once, sha2Result)
 
       // SHA3
-      let sha3Once = SHA3(variant: .sha224).calculate(for: input.bytes)
+      let sha3Once = SHA3(variant: .sha224).calculate(for: input.byteArray)
 
       var sha3Partial = SHA3(variant: .sha224)
       for batch in input.batched(by: 17) {
-        _ = try sha3Partial.update(withBytes: batch.bytes)
+        _ = try sha3Partial.update(withBytes: batch.byteArray)
       }
       let sha3Result = try sha3Partial.finish()
       XCTAssertEqual(sha3Once, sha3Result)

--- a/Tests/CryptoSwiftTests/SignatureVerificationTests.swift
+++ b/Tests/CryptoSwiftTests/SignatureVerificationTests.swift
@@ -37,7 +37,7 @@ final class SignatureVerificationTests: XCTestCase {
           continue
         }
         
-        let rsa = try RSA(publicDER: publicDerData.bytes)
+        let rsa = try RSA(publicDER: publicDerData.byteArray)
         
         guard
           let signedMessageData = Data(base64Encoded: testVector.signedMessage)
@@ -46,7 +46,7 @@ final class SignatureVerificationTests: XCTestCase {
           continue
         }
         
-        let result = try rsa.verify(signature: signedMessageData.bytes,
+        let result = try rsa.verify(signature: signedMessageData.byteArray,
                                     for: testVector.originalMessage.bytes,
                                     variant: testVector.variant)
         XCTAssertTrue(result, "Verification failed for test vector with id `\(testVector.id)`")


### PR DESCRIPTION
Rename the `bytes` computed property in the extension on Data to `byteArray` to avoid clashing with new `bytes: RawSpan` property added in [SE-0456](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0456-stdlib-span-properties.md) for Swift 6.2

Fixes #1073

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:
- rename the `bytes` computed property in the extension on `Data` to `byteArray`.
- this is a breaking change, but nonetheless necessary for compatibility with Xcode 26
