### PR TITLE
docs: Fix typos in comment

### DIFF
--- a/Sources/CryptoSwift/Blowfish.swift
+++ b/Sources/CryptoSwift/Blowfish.swift
@@ -535,7 +535,7 @@ extension Blowfish: Cipher {
     out.reserveCapacity(bytes.count)
 
     for chunk in Array(bytes).batched(by: Blowfish.blockSize) {
-      out += self.decryptWorker.decrypt(block: chunk) // FIXME: copying here is innefective
+      out += self.decryptWorker.decrypt(block: chunk) // FIXME: copying here is ineffective
     }
 
     out = self.padding.remove(from: out, blockSize: Blowfish.blockSize)

--- a/Tests/CryptoSwiftTests/RSATests.swift
+++ b/Tests/CryptoSwiftTests/RSATests.swift
@@ -548,7 +548,7 @@ final class RSATests: XCTestCase {
               continue
             }
 
-            // Our Message is too long for some of our hashing / padding schemes. When this happens we should encouter an error and our test value should be empty.
+            // Our Message is too long for some of our hashing / padding schemes. When this happens we should encounter an error and our test value should be empty.
             if test.value == "" {
               XCTAssertThrowsError(try rsa.sign(message.key.bytes, variant: variant), "Signature<\(test.key)>::Did not throw error")
             } else {


### PR DESCRIPTION
Fixes typos:

 - innefective-> ineffective
 - encouter -> encounter 

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

