### PR TITLE
Enable LibraryEvolution since the library is stable and avoid ABI bre…

### DIFF
--- a/CryptoSwift.podspec
+++ b/CryptoSwift.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/CryptoSwift/**/*.swift"
   s.requires_arc = true
   s.resource_bundles = {'CryptoSwift' => ['Sources/CryptoSwift/PrivacyInfo.xcprivacy']}
+  s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 end

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,11 @@ let package = Package(
     )
   ],
   targets: [
-    .target(name: "CryptoSwift", resources: [.copy("PrivacyInfo.xcprivacy")]),
+    .target(
+      name: "CryptoSwift", 
+      resources: [.copy("PrivacyInfo.xcprivacy")],
+      swiftSettings: [.unsafeFlags(["-enable-library-evolution"])]
+    ),
     .testTarget(name: "CryptoSwiftTests", dependencies: ["CryptoSwift"])
   ],
   swiftLanguageVersions: [.v5]


### PR DESCRIPTION
Enable LibraryEvolution since the library is stable and avoid ABI breaking issue when an xcframework uses SwiftyRSA

Fixes #

Checklist:
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [ ] Tests added.

Changes proposed in this pull request:
-

Enable LibraryEvolution since the library is stable and avoid ABI breaking issue when an xcframework uses SwiftyRSA

Example.

- MyLibrary is compiled to xcframework and it uses SwiftyRSA version x.1
- MyLibrary is used in application A, that uses SwiftyRSA version x.2
- SwiftyRSA version x.2 only reorders/inserts a new public function to a class, but without Library Evolution on, that can cause ABI breaking issue -> crash at runtime of application A, unexpected behaviour.

Benefits for prebuilt xcframework:

- ABI resilient
- Xcode/swift version compatibility