### PR TITLE
O(1) bit shift operation for UInt128

### DIFF
--- a/Sources/CryptoSwift/UInt128.swift
+++ b/Sources/CryptoSwift/UInt128.swift
@@ -14,9 +14,9 @@
 //
 
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+  import FoundationEssentials
 #else
-import Foundation
+  import Foundation
 #endif
 
 struct UInt128: Equatable, ExpressibleByIntegerLiteral {
@@ -31,9 +31,9 @@ struct UInt128: Equatable, ExpressibleByIntegerLiteral {
   init(_ raw: Array<UInt8>) {
     precondition(raw.count >= 16, "UInt128 requires at least 16 bytes")
     let a = UInt64(raw[0]) << 56 | UInt64(raw[1]) << 48 | UInt64(raw[2]) << 40 | UInt64(raw[3]) << 32 |
-            UInt64(raw[4]) << 24 | UInt64(raw[5]) << 16 | UInt64(raw[6]) << 8  | UInt64(raw[7])
+      UInt64(raw[4]) << 24 | UInt64(raw[5]) << 16 | UInt64(raw[6]) << 8 | UInt64(raw[7])
     let b = UInt64(raw[8]) << 56 | UInt64(raw[9]) << 48 | UInt64(raw[10]) << 40 | UInt64(raw[11]) << 32 |
-            UInt64(raw[12]) << 24 | UInt64(raw[13]) << 16 | UInt64(raw[14]) << 8  | UInt64(raw[15])
+      UInt64(raw[12]) << 24 | UInt64(raw[13]) << 16 | UInt64(raw[14]) << 8 | UInt64(raw[15])
     self.init((a, b))
   }
 

--- a/Sources/CryptoSwift/UInt128.swift
+++ b/Sources/CryptoSwift/UInt128.swift
@@ -76,13 +76,15 @@ struct UInt128: Equatable, ExpressibleByIntegerLiteral {
   }
 
   static func >> (value: UInt128, by: Int) -> UInt128 {
-    var result = value
-    for _ in 0..<by {
-      let a = result.i.a >> 1
-      let b = result.i.b >> 1 + ((result.i.a & 1) << 63)
-      result = UInt128((a, b))
+    guard by > 0 else { return value }
+    if by >= 128 { return UInt128(a: 0, b: 0) }
+    if by >= 64 {
+      return UInt128(a: 0, b: value.i.a >> (by - 64))
     }
-    return result
+    let a = value.i.a >> by
+    let b = (value.i.b >> by) | (value.i.a << (64 - by))
+    let a = value.i.a >> by
+    return UInt128(a: a, b: b)
   }
 
   // Equatable.

--- a/Sources/CryptoSwift/UInt128.swift
+++ b/Sources/CryptoSwift/UInt128.swift
@@ -77,10 +77,8 @@ struct UInt128: Equatable, ExpressibleByIntegerLiteral {
 
   static func >> (value: UInt128, by: Int) -> UInt128 {
     guard by > 0 else { return value }
-    if by >= 128 { return UInt128(a: 0, b: 0) }
-    if by >= 64 {
-      return UInt128(a: 0, b: value.i.a >> (by - 64))
-    }
+    guard by < 128 else { return UInt128(a: 0, b: 0) }
+    guard by < 64 else { return UInt128(a: 0, b: value.i.a >> (by - 64)) }
     let a = value.i.a >> by
     let b = (value.i.b >> by) | (value.i.a << (64 - by))
     let a = value.i.a >> by

--- a/Sources/CryptoSwift/UInt128.swift
+++ b/Sources/CryptoSwift/UInt128.swift
@@ -81,7 +81,6 @@ struct UInt128: Equatable, ExpressibleByIntegerLiteral {
     guard by < 64 else { return UInt128(a: 0, b: value.i.a >> (by - 64)) }
     let a = value.i.a >> by
     let b = (value.i.b >> by) | (value.i.a << (64 - by))
-    let a = value.i.a >> by
     return UInt128(a: a, b: b)
   }
 


### PR DESCRIPTION
Fixes #

Checklist:
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Formatted with [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
- [x] Tests added.

Changes proposed in this pull request:
- Replace the O(n) loop-based `>>` right-shift operator on `UInt128` with an O(1) direct bit-manipulation implementation. The previous code shifted one bit at a time in a loop (`for _ in 0..<by`), degrading linearly with the shift amount. The new implementation handles all cases in constant time: early exits for shift ≤ 0, shift ≥ 128, and shift ≥ 64, with a single-expression bit combine for the general case (`(value.i.b >> by) | (value.i.a << (64 - by))`).